### PR TITLE
ci(LUKE-164): CI probes the PR's own preview for the deployed shape

### DIFF
--- a/.github/workflows/preview-probe.yml
+++ b/.github/workflows/preview-probe.yml
@@ -1,0 +1,50 @@
+name: Preview probe
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+  deployments: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# The one check that sees what Vercel built. Every other job here reads the
+# tree; this one waits for the PR's own preview through the GitHub deployment
+# record and sends it the requests the clients make (`apps/web/server/preview-probe.ts`
+# says which and why), so a preset and a `vercel.json` that disagree fail the
+# PR that would deploy them rather than the five merges after it.
+jobs:
+  probe:
+    name: Preview shape
+    # The preview is behind Deployment Protection, and the way through it is a
+    # project setting Dean opens: the Protection Bypass secret, or the OPTIONS
+    # Allowlist. The repository variable PREVIEW_PROBE_DOOR names which one
+    # stands (`bypass-secret` or `options-allowlist`); until it is set there
+    # is no way to see the deployed shape and the job says so by not running,
+    # rather than by a red check on every PR or a green one that saw nothing.
+    # A merge group has no preview, and a fork's PR has no preview and no
+    # secrets, so neither is probed.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && vars.PREVIEW_PROBE_DOOR != ''
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      # The head commit, not the merge commit: Vercel builds the branch, and
+      # the caller list the probe derives has to be the one that preview built.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/setup
+      - run: pnpm --dir apps/web exec tsx scripts/preview-probe.ts
+        env:
+          PREVIEW_PROBE_DOOR: ${{ vars.PREVIEW_PROBE_DOOR }}
+          PREVIEW_PROBE_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/apps/web/scripts/preview-probe.ts
+++ b/apps/web/scripts/preview-probe.ts
@@ -3,11 +3,17 @@ import { FetchHttpClient, FileSystem } from "@effect/platform";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
 import { Config, Effect, Layer, Option, Redacted, Schema } from "effect";
 import {
+  PREVIEW_STATE,
+  type PreviewReading,
+  waitForPreview,
+} from "../server/preview-deployment.js";
+import {
   type PlannedRequest,
   PROBE_DOOR,
   PROBE_REQUEST_INIT,
   ProbeDoorSchema,
   type ProbeReport,
+  type ProbeTarget,
   planProbes,
   probeDeployment,
   probeFailures,
@@ -16,20 +22,24 @@ import {
 } from "../server/preview-probe.js";
 
 /**
- * Reads the deployed shape of the address handed to it and exits non-zero
- * when a request the clients make is not answered by the deployment's own
- * handler:
+ * Reads the deployed shape of a preview, or of any address handed to it, and
+ * exits non-zero when a request the clients make is not answered by the
+ * deployment's own handler:
  *
+ *   PREVIEW_PROBE_DOOR=<door> PREVIEW_PROBE_SHA=<head> GITHUB_TOKEN=… \
+ *     pnpm --dir apps/web exec tsx scripts/preview-probe.ts
  *   PREVIEW_PROBE_DOOR=bypass-secret \
  *     pnpm --dir apps/web exec tsx scripts/preview-probe.ts --url https://tryluke.dev
  *
- * That is the Services preset sitting runbook's read of production after a
- * merge, over the whole derived list rather than its eight requests alone.
- * The door names which project setting the probe relies on; the bypass door
- * sends `VERCEL_AUTOMATION_BYPASS_SECRET` when one is set and otherwise plain
- * GETs, which an unprotected production answers and a protected preview
- * redirects, reported as such. The report is written to standard output and,
- * where `GITHUB_STEP_SUMMARY` names a file, appended there as a table.
+ * Without `--url` it waits on the head's preview through the GitHub
+ * deployment records, which is what CI does; with it, it probes the address
+ * given, which is the Services preset sitting runbook's read of production
+ * after a merge. The door names which project setting the probe relies on;
+ * the bypass door sends `VERCEL_AUTOMATION_BYPASS_SECRET` when one is set and
+ * otherwise plain GETs, which an unprotected production answers and a
+ * protected preview redirects, reported as such. The report is written to
+ * standard output and, where `GITHUB_STEP_SUMMARY` names a file, appended
+ * there as a table.
  */
 
 const WEB = join(import.meta.dirname, "..");
@@ -38,6 +48,9 @@ const URL_FLAG = "--url";
 
 const ENV = {
   DOOR: "PREVIEW_PROBE_DOOR",
+  SHA: "PREVIEW_PROBE_SHA",
+  REPOSITORY: "GITHUB_REPOSITORY",
+  TOKEN: "GITHUB_TOKEN",
   BYPASS_SECRET: "VERCEL_AUTOMATION_BYPASS_SECRET",
   STEP_SUMMARY: "GITHUB_STEP_SUMMARY",
 } as const;
@@ -49,9 +62,22 @@ const bypassSecretConfig = Config.option(Config.redacted(ENV.BYPASS_SECRET)).pip
 );
 const stepSummaryConfig = Config.option(Config.string(ENV.STEP_SUMMARY));
 
-class AddressMissing extends Schema.TaggedError<AddressMissing>()("AddressMissing", {}) {
+class BypassSecretMissing extends Schema.TaggedError<BypassSecretMissing>()(
+  "BypassSecretMissing",
+  {},
+) {
   override get message(): string {
-    return `${URL_FLAG} <address> names the deployment to probe`;
+    return `${ENV.DOOR} names the ${PROBE_DOOR.BYPASS_SECRET} door and ${ENV.BYPASS_SECRET} is empty: a protected preview would only redirect`;
+  }
+}
+
+class PreviewNotBuilt extends Schema.TaggedError<PreviewNotBuilt>()("PreviewNotBuilt", {
+  id: Schema.Number,
+  state: Schema.String,
+  description: Schema.String,
+}) {
+  override get message(): string {
+    return `deployment record ${this.id} (Preview) ended ${this.state}: ${this.description}`;
   }
 }
 
@@ -101,6 +127,10 @@ function renderSummary(report: ProbeReport): string {
   ].join("\n");
 }
 
+function renderNotAffected(reading: PreviewReading & { readonly kind: "not-affected" }): string {
+  return `deployment record ${reading.id} (Preview) was skipped by Vercel's ignoreCommand: nothing under the deployed tree changed, so there is no preview of this head to probe\n`;
+}
+
 function appendStepSummary(text: string): Effect.Effect<void, never, FileSystem.FileSystem> {
   return Effect.gen(function* () {
     const path = yield* stepSummaryConfig;
@@ -110,17 +140,53 @@ function appendStepSummary(text: string): Effect.Effect<void, never, FileSystem.
   }).pipe(Effect.orDie);
 }
 
+const describeReading = (reading: PreviewReading) =>
+  write(`preview: ${reading.kind}${"id" in reading ? ` (record ${reading.id})` : ""}\n`);
+
+/** The address to probe: the one given, or the head's preview once its record has settled; none when Vercel skipped the build. */
+const resolveTarget = (bypassSecret: ProbeTarget["bypassSecret"]) =>
+  Effect.gen(function* () {
+    const given = addressArgument(process.argv.slice(2));
+    if (given !== undefined) return { address: given, bypassSecret };
+    const source = {
+      repository: yield* Config.string(ENV.REPOSITORY),
+      sha: yield* Config.string(ENV.SHA),
+      token: yield* Config.redacted(ENV.TOKEN),
+    };
+    const reading = yield* waitForPreview(source, { onReading: describeReading });
+    switch (reading.kind) {
+      case PREVIEW_STATE.READY:
+        return { address: reading.address, bypassSecret };
+      case PREVIEW_STATE.NOT_AFFECTED:
+        return reading;
+      case PREVIEW_STATE.NOT_BUILT:
+        return yield* new PreviewNotBuilt(reading);
+    }
+  });
+
 const program = Effect.gen(function* () {
-  const address = addressArgument(process.argv.slice(2));
-  if (address === undefined) return yield* new AddressMissing();
   const door = yield* doorConfig;
   const bypassSecret =
     door === PROBE_DOOR.BYPASS_SECRET ? yield* bypassSecretConfig : Option.none();
+  if (
+    door === PROBE_DOOR.BYPASS_SECRET &&
+    Option.isNone(bypassSecret) &&
+    addressArgument(process.argv.slice(2)) === undefined
+  ) {
+    return yield* new BypassSecretMissing();
+  }
   const plan = planProbes(door, yield* readProbePaths({ repoRoot: REPO_ROOT, web: WEB }));
+  const target = yield* resolveTarget(bypassSecret);
+  if ("kind" in target) {
+    const notice = renderNotAffected(target);
+    yield* write(notice);
+    yield* appendStepSummary(`### Deployed shape\n\n${notice}`);
+    return;
+  }
   const report: ProbeReport = {
     door,
-    address,
-    results: yield* probeDeployment({ address, bypassSecret }, plan),
+    address: target.address,
+    results: yield* probeDeployment(target, plan),
   };
   yield* write(renderReport(report));
   yield* appendStepSummary(renderSummary(report));

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -126,7 +126,13 @@ function's own 404 never carries — with the runbook's eight requests held to
 their exact codes besides, because on 2026-09-11 five production deploys
 failed in a row while nothing in CI could see the deployed shape (LUKE-164).
 Behind Deployment Protection it needs one of two doors, the bypass secret
-sent as a header or the OPTIONS allowlist, and names which it relies on. The
+sent as a header or the OPTIONS allowlist, and names which it relies on.
+CI's Preview probe job (`.github/workflows/preview-probe.yml`) runs it
+against a PR's own preview, found through the head commit's GitHub
+deployment record (`server/preview-deployment.ts`), once the repository
+variable `PREVIEW_PROBE_DOOR` names the door; until then the job does not
+run, since a check that cannot see the deployment would be green over
+nothing. The
 table is its own file so a `vercel.ts` can one day import it and `vercel.json`
 be deleted (LUKE-183); Vercel evaluates a config module in plain Node and
 bundles only its relative imports, which takes a JSON table and not this

--- a/apps/web/server/preview-deployment.ts
+++ b/apps/web/server/preview-deployment.ts
@@ -1,0 +1,238 @@
+import * as HttpClient from "@effect/platform/HttpClient";
+import type * as HttpClientError from "@effect/platform/HttpClientError";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
+import { Duration, Effect, type Redacted, Schedule, Schema } from "effect";
+import type { ParseError } from "effect/ParseResult";
+import { TRANSPORT_RETRY } from "./preview-probe.js";
+
+/**
+ * The PR's own preview, found through the GitHub deployment record Vercel's
+ * app writes for the head commit. The record is the one signal that names
+ * the deployment built from exactly this commit — an alias like the branch
+ * URL keeps serving the previous build until the new one is promoted, which
+ * is how a probe during the 2026-09-11 incident read 404 from a deployment
+ * that was not the one under test — so the address probed is always the
+ * record's own, and the wait is on that record's status rather than on a
+ * clock or a guess. A build Vercel's `ignoreCommand` skipped is its own
+ * state, not a failure: nothing under the deployed tree changed, so there is
+ * no preview of the head and nothing to see. A cancelled build is not the
+ * end either: Vercel starts two deployments of a freshly pushed PR head and
+ * cancels one within seconds, writing the record `inactive`, and the record
+ * is moved to `success` with the surviving build's own address only when
+ * that build completes, which the API showed minutes late on 2026-09-12; so
+ * `inactive` is waited through, and only a build that failed, or the wait's
+ * own budget, ends the wait with nothing to see.
+ */
+
+const GITHUB_API = "https://api.github.com";
+const GITHUB_HEADERS = {
+  accept: "application/vnd.github+json",
+  "x-github-api-version": "2022-11-28",
+  "user-agent": "luke-preview-probe",
+} as const;
+/** The environment Vercel's GitHub app writes on a preview's deployment record. */
+const VERCEL_PREVIEW_ENVIRONMENT = "Preview";
+const DEPLOYMENT_PAGE = "10";
+/** Vercel's own words on the status it writes for a build its `ignoreCommand` skipped, compared whole. */
+const VERCEL_SKIPPED_DESCRIPTION = "Skipped - Not affected";
+
+export const DEPLOYMENT_STATE = {
+  ERROR: "error",
+  FAILURE: "failure",
+  INACTIVE: "inactive",
+  IN_PROGRESS: "in_progress",
+  QUEUED: "queued",
+  PENDING: "pending",
+  SUCCESS: "success",
+} as const;
+type DeploymentState = (typeof DEPLOYMENT_STATE)[keyof typeof DEPLOYMENT_STATE];
+
+export const DeploymentRecord = Schema.Struct({
+  id: Schema.Number,
+  sha: Schema.String,
+  environment: Schema.String,
+  created_at: Schema.String,
+});
+export type DeploymentRecord = typeof DeploymentRecord.Type;
+const DeploymentRecords = Schema.Array(DeploymentRecord);
+
+export const DeploymentStatus = Schema.Struct({
+  state: Schema.Literal(...Object.values(DEPLOYMENT_STATE)),
+  description: Schema.optional(Schema.NullOr(Schema.String)),
+  environment_url: Schema.optional(Schema.NullOr(Schema.String)),
+  target_url: Schema.optional(Schema.NullOr(Schema.String)),
+  created_at: Schema.String,
+});
+export type DeploymentStatus = typeof DeploymentStatus.Type;
+const DeploymentStatuses = Schema.Array(DeploymentStatus);
+
+export const PREVIEW_STATE = {
+  /** No record yet, or its newest status is still on the way to a build's end. */
+  WAITING: "waiting",
+  /** The build completed and the record names its address. */
+  READY: "ready",
+  /** Vercel's `ignoreCommand` found nothing of the deployed tree changed, so no preview was built for this head. */
+  NOT_AFFECTED: "not-affected",
+  /** The build failed, or ended without an address: there is no deployment to see. */
+  NOT_BUILT: "not-built",
+} as const;
+
+export type PreviewReading =
+  | { readonly kind: typeof PREVIEW_STATE.WAITING }
+  | { readonly kind: typeof PREVIEW_STATE.READY; readonly id: number; readonly address: string }
+  | { readonly kind: typeof PREVIEW_STATE.NOT_AFFECTED; readonly id: number }
+  | {
+      readonly kind: typeof PREVIEW_STATE.NOT_BUILT;
+      readonly id: number;
+      readonly state: DeploymentState;
+      readonly description: string;
+    };
+
+function newestFirst<T extends { readonly created_at: string }>(items: readonly T[]): readonly T[] {
+  return [...items].sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+}
+
+/** The newest preview record for the head and its newest status, read as one of the four states. */
+export function decidePreview(
+  records: readonly DeploymentRecord[],
+  statusesOf: (record: DeploymentRecord) => readonly DeploymentStatus[],
+): PreviewReading {
+  const record = newestFirst(
+    records.filter((candidate) => candidate.environment === VERCEL_PREVIEW_ENVIRONMENT),
+  )[0];
+  if (record === undefined) return { kind: PREVIEW_STATE.WAITING };
+  const status = newestFirst(statusesOf(record))[0];
+  if (status === undefined) return { kind: PREVIEW_STATE.WAITING };
+  const description = status.description ?? "";
+  switch (status.state) {
+    case DEPLOYMENT_STATE.PENDING:
+    case DEPLOYMENT_STATE.QUEUED:
+    case DEPLOYMENT_STATE.IN_PROGRESS:
+      return { kind: PREVIEW_STATE.WAITING };
+    case DEPLOYMENT_STATE.SUCCESS: {
+      const address = status.environment_url ?? status.target_url;
+      return address
+        ? { kind: PREVIEW_STATE.READY, id: record.id, address }
+        : { kind: PREVIEW_STATE.NOT_BUILT, id: record.id, state: status.state, description };
+    }
+    case DEPLOYMENT_STATE.INACTIVE:
+      return description === VERCEL_SKIPPED_DESCRIPTION
+        ? { kind: PREVIEW_STATE.NOT_AFFECTED, id: record.id }
+        : { kind: PREVIEW_STATE.WAITING };
+    case DEPLOYMENT_STATE.FAILURE:
+    case DEPLOYMENT_STATE.ERROR:
+      return { kind: PREVIEW_STATE.NOT_BUILT, id: record.id, state: status.state, description };
+  }
+}
+
+export interface PreviewSource {
+  /** `owner/name`, as GitHub spells `GITHUB_REPOSITORY`. */
+  readonly repository: string;
+  /** The head commit whose preview is wanted, never the merge commit: Vercel builds the branch. */
+  readonly sha: string;
+  readonly token: Redacted.Redacted<string>;
+}
+
+function githubRead(
+  source: PreviewSource,
+  path: string,
+  params: Readonly<Record<string, string>>,
+): HttpClientRequest.HttpClientRequest {
+  return HttpClientRequest.get(`${GITHUB_API}${path}`).pipe(
+    HttpClientRequest.setUrlParams(params),
+    HttpClientRequest.bearerToken(source.token),
+    HttpClientRequest.setHeaders(GITHUB_HEADERS),
+  );
+}
+
+/** One read of the head's preview from the deployment records, a dropped connection or a refused read retried a few times. */
+function readPreview(
+  source: PreviewSource,
+): Effect.Effect<
+  PreviewReading,
+  HttpClientError.HttpClientError | ParseError,
+  HttpClient.HttpClient
+> {
+  return Effect.gen(function* () {
+    const client = HttpClient.filterStatusOk(yield* HttpClient.HttpClient);
+    const records = yield* client
+      .execute(
+        githubRead(source, `/repos/${source.repository}/deployments`, {
+          sha: source.sha,
+          environment: VERCEL_PREVIEW_ENVIRONMENT,
+          per_page: DEPLOYMENT_PAGE,
+        }),
+      )
+      .pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(DeploymentRecords)), Effect.scoped);
+    const newest = newestFirst(records)[0];
+    if (newest === undefined) return decidePreview([], () => []);
+    const statuses = yield* client
+      .execute(
+        githubRead(source, `/repos/${source.repository}/deployments/${newest.id}/statuses`, {
+          per_page: DEPLOYMENT_PAGE,
+        }),
+      )
+      .pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(DeploymentStatuses)), Effect.scoped);
+    return decidePreview([newest], () => statuses);
+  }).pipe(
+    Effect.retry({
+      schedule: TRANSPORT_RETRY,
+      while: (error) => error._tag === "RequestError" || error._tag === "ResponseError",
+    }),
+  );
+}
+
+export interface PreviewWait {
+  readonly intervalMs: number;
+  readonly attempts: number;
+}
+
+/**
+ * Twenty minutes. On 2026-09-12 a preview's record appeared about 25 s after
+ * the push and reached success 85–115 s later; the rest of the budget is
+ * Vercel's build queue on a day with many open branches.
+ */
+const DEFAULT_PREVIEW_WAIT: PreviewWait = { intervalMs: 15_000, attempts: 80 };
+
+export class PreviewNotReady extends Schema.TaggedError<PreviewNotReady>()("PreviewNotReady", {
+  sha: Schema.String,
+  waitedMs: Schema.Number,
+}) {
+  override get message(): string {
+    return `no preview for ${this.sha} reached a build's end within ${this.waitedMs} ms`;
+  }
+}
+
+/** The head's preview once its record has settled, read on a schedule until it does or the budget ends. */
+export function waitForPreview(
+  source: PreviewSource,
+  options: {
+    readonly wait?: PreviewWait;
+    /** Told each reading as it lands, so a log shows the wait rather than silence. */
+    readonly onReading?: (reading: PreviewReading) => Effect.Effect<void>;
+  } = {},
+): Effect.Effect<
+  Exclude<PreviewReading, { readonly kind: typeof PREVIEW_STATE.WAITING }>,
+  PreviewNotReady | HttpClientError.HttpClientError | ParseError,
+  HttpClient.HttpClient
+> {
+  const wait = options.wait ?? DEFAULT_PREVIEW_WAIT;
+  const onReading = options.onReading ?? (() => Effect.void);
+  return Effect.gen(function* () {
+    const reading = yield* Effect.repeat(readPreview(source).pipe(Effect.tap(onReading)), {
+      schedule: Schedule.identity<PreviewReading>().pipe(
+        Schedule.zipLeft(Schedule.spaced(Duration.millis(wait.intervalMs))),
+        Schedule.zipLeft(Schedule.recurs(wait.attempts)),
+      ),
+      until: (reading) => reading.kind !== PREVIEW_STATE.WAITING,
+    });
+    if (reading.kind === PREVIEW_STATE.WAITING) {
+      return yield* new PreviewNotReady({
+        sha: source.sha,
+        waitedMs: wait.intervalMs * wait.attempts,
+      });
+    }
+    return reading;
+  });
+}

--- a/apps/web/server/preview-probe.ts
+++ b/apps/web/server/preview-probe.ts
@@ -248,7 +248,7 @@ export interface ProbeReport {
 export const PROBE_REQUEST_INIT: RequestInit = { redirect: "manual" };
 
 /** A dropped connection is retried a few times; an answer, whatever its status, is never retried. */
-const TRANSPORT_RETRY = Schedule.exponential(Duration.seconds(1)).pipe(
+export const TRANSPORT_RETRY = Schedule.exponential(Duration.seconds(1)).pipe(
   Schedule.intersect(Schedule.recurs(3)),
 );
 const PROBE_CONCURRENCY = 4;

--- a/apps/web/tests/preview-deployment.test.ts
+++ b/apps/web/tests/preview-deployment.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
+import { Effect, Exit, Fiber, Redacted, TestClock } from "effect";
+import { test } from "vitest";
+import {
+  DEPLOYMENT_STATE,
+  type DeploymentRecord,
+  type DeploymentStatus,
+  decidePreview,
+  PREVIEW_STATE,
+  waitForPreview,
+} from "../server/preview-deployment.js";
+
+const PREVIEW = "https://luke-abc123-stage-review.vercel.app";
+const SOURCE = {
+  repository: "ReviewStage/luke",
+  sha: "e8dd1314fdbbb8fe5d28f7e9863a3a87e4c3c7a8",
+  token: Redacted.make("ghs_token"),
+};
+
+const record = (id: number, created_at: string, environment = "Preview"): DeploymentRecord => ({
+  id,
+  sha: SOURCE.sha,
+  environment,
+  created_at,
+});
+
+const status = (
+  state: DeploymentStatus["state"],
+  created_at: string,
+  rest: Partial<Pick<DeploymentStatus, "description" | "environment_url" | "target_url">> = {},
+): DeploymentStatus => ({ state, created_at, ...rest });
+
+test("the newest preview record's newest status decides the reading, a cancelled one waited through", () => {
+  const older = record(1, "2026-09-12T08:00:00Z");
+  const newer = record(2, "2026-09-12T08:05:00Z");
+  const production = record(3, "2026-09-12T08:06:00Z", "Production");
+  const readings = [
+    decidePreview([], () => []),
+    decidePreview([production], () => [status(DEPLOYMENT_STATE.SUCCESS, "2026-09-12T08:07:00Z")]),
+    decidePreview([older, newer], () => []),
+    decidePreview([older, newer], (which) =>
+      which.id === 2 ? [status(DEPLOYMENT_STATE.IN_PROGRESS, "2026-09-12T08:05:01Z")] : [],
+    ),
+    decidePreview([older, newer], () => [
+      status(DEPLOYMENT_STATE.PENDING, "2026-09-12T08:05:01Z"),
+      status(DEPLOYMENT_STATE.SUCCESS, "2026-09-12T08:07:00Z", {
+        description: "Deployment has completed",
+        environment_url: PREVIEW,
+      }),
+    ]),
+    decidePreview([newer], () => [
+      status(DEPLOYMENT_STATE.SUCCESS, "2026-09-12T08:07:00Z", { target_url: PREVIEW }),
+    ]),
+    decidePreview([newer], () => [
+      status(DEPLOYMENT_STATE.INACTIVE, "2026-09-12T08:05:01Z", {
+        description: "Skipped - Not affected",
+        environment_url: PREVIEW,
+      }),
+    ]),
+    decidePreview([newer], () => [
+      status(DEPLOYMENT_STATE.INACTIVE, "2026-09-12T08:05:01Z", {
+        description: "Canceled from the Vercel Dashboard",
+      }),
+    ]),
+    decidePreview([newer], () => [
+      status(DEPLOYMENT_STATE.FAILURE, "2026-09-12T08:06:00Z", {
+        description: "Deployment has failed",
+      }),
+    ]),
+    decidePreview([newer], () => [status(DEPLOYMENT_STATE.SUCCESS, "2026-09-12T08:07:00Z")]),
+  ];
+  assert.deepEqual(readings, [
+    { kind: PREVIEW_STATE.WAITING },
+    { kind: PREVIEW_STATE.WAITING },
+    { kind: PREVIEW_STATE.WAITING },
+    { kind: PREVIEW_STATE.WAITING },
+    { kind: PREVIEW_STATE.READY, id: 2, address: PREVIEW },
+    { kind: PREVIEW_STATE.READY, id: 2, address: PREVIEW },
+    { kind: PREVIEW_STATE.NOT_AFFECTED, id: 2 },
+    { kind: PREVIEW_STATE.WAITING },
+    {
+      kind: PREVIEW_STATE.NOT_BUILT,
+      id: 2,
+      state: DEPLOYMENT_STATE.FAILURE,
+      description: "Deployment has failed",
+    },
+    { kind: PREVIEW_STATE.NOT_BUILT, id: 2, state: DEPLOYMENT_STATE.SUCCESS, description: "" },
+  ]);
+});
+
+interface GithubRead {
+  readonly path: string;
+  readonly sha: string | null;
+  readonly authorization: string | null;
+}
+
+/** GitHub's deployment records for the head, answered from a script of statuses, one entry per list call. */
+function github(script: readonly (readonly DeploymentStatus[] | undefined)[], reads: GithubRead[]) {
+  return fakeHttpClientLayer((url, init) => {
+    const request = new URL(url);
+    reads.push({
+      path: request.pathname,
+      sha: request.searchParams.get("sha"),
+      authorization: new Headers(init.headers).get("authorization"),
+    });
+    const listCalls = reads.filter((read) => read.sha !== null).length;
+    const statuses = script[listCalls - 1];
+    if (request.pathname === `/repos/${SOURCE.repository}/deployments`) {
+      return Response.json(statuses === undefined ? [] : [record(7, "2026-09-12T08:05:00Z")]);
+    }
+    return Response.json(statuses ?? []);
+  });
+}
+
+it.effect("the wait reads the records on its schedule until the preview's record settles", () =>
+  Effect.gen(function* () {
+    const reads: GithubRead[] = [];
+    const layer = github(
+      [
+        undefined,
+        [status(DEPLOYMENT_STATE.IN_PROGRESS, "2026-09-12T08:05:01Z")],
+        [status(DEPLOYMENT_STATE.SUCCESS, "2026-09-12T08:06:30Z", { environment_url: PREVIEW })],
+      ],
+      reads,
+    );
+    const fiber = yield* Effect.fork(
+      waitForPreview(SOURCE, { wait: { intervalMs: 15_000, attempts: 5 } }).pipe(
+        Effect.provide(layer),
+      ),
+    );
+    yield* TestClock.adjust("15 seconds");
+    yield* TestClock.adjust("15 seconds");
+    const reading = yield* Fiber.join(fiber);
+    assert.deepEqual(reading, { kind: PREVIEW_STATE.READY, id: 7, address: PREVIEW });
+    assert.deepEqual(
+      reads.map((read) => read.path),
+      [
+        `/repos/${SOURCE.repository}/deployments`,
+        `/repos/${SOURCE.repository}/deployments`,
+        `/repos/${SOURCE.repository}/deployments/7/statuses`,
+        `/repos/${SOURCE.repository}/deployments`,
+        `/repos/${SOURCE.repository}/deployments/7/statuses`,
+      ],
+    );
+    assert.deepEqual(
+      new Set(reads.map((read) => read.authorization)),
+      new Set(["Bearer ghs_token"]),
+    );
+    assert.deepEqual(
+      new Set(reads.filter((read) => read.sha !== null).map((read) => read.sha)),
+      new Set([SOURCE.sha]),
+    );
+  }),
+);
+
+it.effect(
+  "a wait whose budget ends before the record settles fails by name rather than probing nothing",
+  () =>
+    Effect.gen(function* () {
+      const reads: GithubRead[] = [];
+      const fiber = yield* Effect.fork(
+        waitForPreview(SOURCE, { wait: { intervalMs: 1_000, attempts: 2 } }).pipe(
+          Effect.provide(github([], reads)),
+        ),
+      );
+      yield* TestClock.adjust("1 second");
+      yield* TestClock.adjust("1 second");
+      const exit = yield* Fiber.await(fiber);
+      assert.equal(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        assert.equal(exit.cause._tag, "Fail");
+        if (exit.cause._tag === "Fail") assert.equal(exit.cause.error._tag, "PreviewNotReady");
+      }
+      assert.equal(reads.length, 3);
+    }),
+);

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -131,8 +131,9 @@ are the process's own edges, one runtime each:
   them through `NodeRuntime.runMain` over the `NodeFileSystem` layer rather
   than awaiting `node:fs/promises` calls of its own.
 - `apps/web/scripts/preview-probe.ts`, the deployed-shape probe, on the same
-  terms: probing a deployment over `FetchHttpClient` and appending the step
-  summary are effects of one command's life, run through
+  terms: waiting on the deployment record, probing the preview over
+  `FetchHttpClient`, and appending the step summary are effects of one
+  command's life, run through
   `NodeRuntime.runMain` over the fetch client and `NodeContext`, so the run
   is the edge and nothing of it outlives the process.
 - the two renderer roots, `apps/desktop/src/renderer/index.tsx` and

--- a/docs/runbooks/services-preset-sitting.md
+++ b/docs/runbooks/services-preset-sitting.md
@@ -101,9 +101,11 @@ failure; the treadmill is the one that can eat a night.
    trigger a deployment.
 4. **Dean redeploys the PR's existing preview from the dashboard.** Not a new
    commit: a push would rebuild under the old detection and prove nothing. The
-   redeploy's build log is the only evidence of the services shape, because
-   the preview URL is behind Deployment Protection and cannot be probed from
-   a sandbox.
+   redeploy's build log is one half of the evidence; the other is the probe
+   below, which a sandbox cannot send by hand while the preview URL stays
+   behind Deployment Protection, and which CI's Preview probe job sends for
+   it once the project opens one of the two doors
+   `apps/web/server/preview-probe.ts` documents.
 5. **Dean reads the two log facts and the eight probes** (below) and reports
    them as they are.
 6. **The worker presses within the minute** by starting the enqueue watcher
@@ -177,7 +179,9 @@ is served and was the one fact the first sitting got right.
 `apps/web/scripts/preview-probe.ts --url <address>` sends these probes to a
 deployment, over the whole list the callers check derives rather than these
 eight alone, and judges each answer by whose it is; it is also the read of
-production after a merge.
+production after a merge. CI's Preview probe workflow runs the same script
+against every PR's own preview, found through the head's GitHub deployment
+record, once the repository variable `PREVIEW_PROBE_DOOR` names the door.
 
 A 401, 405, or 426 each mean the handler is there and refusing the caller.
 **A 404 of Vercel's own anywhere is the failure** (the platform marks its


### PR DESCRIPTION
## Summary

- Part 2 of 2 for LUKE-164, now standing alone on `main` (part 1 merged as `a7773d8b`, #1268). **New file `.github/workflows/preview-probe.yml`** (no existing workflow touched, so W-177's `ci.yml` edits are undisturbed): on `pull_request`, the job waits for the PR's own Vercel preview through the head commit's GitHub deployment record and runs `scripts/preview-probe.ts` against the address the record names, over every caller path the callers check derives, the cron path, the page, and `/eve/v1/health`. A merge group has no preview and a fork has no secrets, so neither is probed.
- **Readiness is the deployment record, on the deployment's own URL.** `apps/web/server/preview-deployment.ts` reads `GET /repos/{repo}/deployments?sha=<head>&environment=Preview` and the newest record's newest status, on a 15 s cadence for at most 20 minutes. `success` → probe its `environment_url`, the one build's unique address; `failure`/`error` → fail (that is the preset-on-key-missing state); `inactive` "Skipped - Not affected" → nothing under the deployed tree changed, no preview of this head exists, said so in the step summary and exit 0. **A cancelled status is waited through, not failed:** measured on this PR's own heads, Vercel starts two deployments of a freshly pushed PR head, cancels one within two seconds (`inactive`, "Canceled from the Vercel Dashboard"), and moves the record to `success` with the surviving build's address only when it completes, which the API surfaced about six minutes after the fact (record 6407815927, environment Preview: cancelled at 08:45:26Z, success stamped 08:47:18Z, visible after 08:52Z). The budget absorbs that lag, and the log prints every reading so a wait is never silent. The ticket's "wait on non-404 from a newly added route" was written against an alias that kept serving the old build; the record's URL names one build and cannot serve another, so the wait is on the record and a 404 there is the finding rather than staleness.
- The job writes a GitHub step summary table (method, path, status, `x-vercel-error`, expected, verdict) so a failure reads without the log.

## Why this PR's own `Preview shape` check reads SKIPPED, and the finding for Dean

The job's `if:` gate requires the repository variable `PREVIEW_PROBE_DOOR` to be set. It is not, so the job is skipped by design on every PR, this one included, on the old base and on the rebased head alike. That gate is deliberate: without a door there is no way to see the deployed shape, and a red check on every PR or a green check that saw nothing would both be worse than a skip that says why.

**Measured on 2026-09-12, the preview cannot be probed from CI without a project change.** On this PR's own preview (`luke-3v1pdlr8f-stage-review.vercel.app`, head `3c2610c5`) every method, including `OPTIONS` and `HEAD`, on `/`, `/eve/v1/health`, `/api/auth/session`, and `/api/cron/pass` answers `302` to `vercel.com/sso-api` with a `_vercel_sso_nonce` cookie. Vercel Authentication covers the whole deployment, and GitHub Actions holds no Vercel session. The only ways through are project settings Dean controls:

- `options-allowlist`: add `/api` and `/eve` to the project's OPTIONS Allowlist (Settings → Deployment Protection). **No secret exists anywhere**; this is the door that does not need what was declined on 2026-09-11. The probe then asserts every handler's preflight answer (405/426, eve's own 404) by the `x-vercel-error` discriminator; it cannot assert GET codes or `GET /`. What it opens: OPTIONS on `/api*` and `/eve*` of previews, i.e. which handlers exist, which production already shows. Set `PREVIEW_PROBE_DOOR=options-allowlist` and the job runs on the next PR.
- `bypass-secret`: a Protection Bypass for Automation secret stored as the repository secret `VERCEL_AUTOMATION_BYPASS_SECRET`, with `PREVIEW_PROBE_DOOR=bypass-secret`. The probe then sends GET exactly as the call sites do and asserts the runbook's exact codes. Declined on 2026-09-11 (a long-lived secret available to any same-repo workflow run in a public repository); recorded here only so the two doors are named side by side.

Neither door is open today, so this PR does not and cannot show a green `Preview shape` run. It is not faked: the check reads `skipped`, and the wiring that a run would exercise is shown below against the real record instead.

## Evidence

- Rebased onto `main` at `6aae30ce` (main's own CI at that sha: TypeScript checks, Postgres migrations and store, Tests 1/4–4/4, CodeQL all `success`). The rebase was conflict-free: part 1's files on `main` are byte-identical to this branch's copies except `apps/web/server/README.md`, whose drift was unrelated hunks that moved on `main`.
- Platform-independent checks: `./scripts/check.sh` on the rebased head `f085effd`: exit 0 (knip, oxlint, typecheck, test, build). Vitest over the harness and four shards: 461 test files, 3,685 tests passed, 1 skipped; no `[vitest-worker]: Timeout calling onTaskUpdate` line, so LUKE-187 did not fire.
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no desktop or UI change).
- **The CLI, as CI would run it, against the rebased head's real record** (`PREVIEW_PROBE_DOOR=options-allowlist`, `PREVIEW_PROBE_SHA=f085effd…`, a personal token, from this sandbox): three readings of `waiting`, then `ready (record 6412836736)`, created 2026-09-12T18:14:46Z; probed at its unique address `luke-cczsu3qpu-stage-review.vercel.app`; 42 of 42 requests `302` → verdict `protected`; `ShapeMismatch: 42 of 42 requests were not answered by the deployment's own handler`; exit 1; the step-summary table written. That is the record wait, the address resolution, the request plan, the protection discriminator, and the exit code all exercised end to end; the one thing not exercised is a handler answering, which needs a door.
- Earlier runs on the old base, for the readings the code names: head `e8dd1314` (record 6407492183, success) read `ready`, 42 of 42 `protected`, exit 1; head `1fa8334b` (record 6407521625, inactive "Skipped - Not affected") read `not-affected`, exit 0; head `8abbe57d` (record 6407815927) read `not-built` by the first cut while its record still said cancelled, which is the finding that made `inactive` a waited-through state, then `ready` once the record settled.
- New tests: 3 in `apps/web/tests/preview-deployment.test.ts` (the ten readings of `decidePreview`, the wait's schedule and the reads it makes, the budget's end failing by name), under `TestClock` against a fake GitHub.

### Visual evidence

- Fixture screenshots inspected: `not applicable` (no UI change).

### Physical-device evidence

- Screenshot or screen recording: `not applicable`
- Physical-notch check: `not performed` (no UI change)
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green. (CI)
- [x] JSON Schema goldens unchanged. (CI)
- [x] Gateway envelope goldens unchanged. (CI)
- [x] No new `as` type assertion. (CI)
- [x] No `effect` import in an OpenClaw-ported file. (CI)
- [x] No new runtime edge: the CLI is the edge #1268 registered; the ADR bullet is amended to name the wait. (CI)
- [x] No new raw async primitives: the wait is `Effect.repeat` over a `Schedule`. (CI)
- [x] Test count: +3 (`apps/web/tests/preview-deployment.test.ts`).
- [x] No hand-rolled file replaced.
- [x] `CLAUDE.md`/`AGENTS.md` untouched; README and runbook paragraphs extended.
- [x] `PRIVACY.md` unchanged: the job reads deployment records and a deployment's status lines; nothing of a user's travels.
- [x] Package deps match imports.

## What CI cannot verify

No macOS job; no desktop change. The job's own effect (probing a real preview through an open door) is unverifiable on this PR by construction: both doors are shut, as measured above, and only Dean can open one.

## Shared files touched

`.github/workflows/preview-probe.yml` is **new**; `ci.yml` and `release.yml` are untouched. `docs/adr/0001-effect.md` (one bullet amended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
