### PR TITLE
refactor(host): the settings store's own methods answer effects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -485,10 +485,10 @@ because P12-04d threads that runtime through `VoiceCapabilityAssembler` to
 own permanent row above; what this file no longer holds is a run of its own.
 `startCapabilities` and `stopCapabilities` are the links' own effects behind
 an `Effect.suspend`, which is what keeps a link read no earlier than the call
-that needs it, and `onSignOut` is `releaseDevice` directly. What the composer still lifts is
-the settings store's three account reads and writes, each an `Effect.promise`
-at the seam rather than a run made inside the session manager, until P12-14c
-takes the store itself onto effects.
+that needs it, and `onSignOut` is `releaseDevice` directly. The three account reads and
+writes it lifted at that seam are lifted no longer: P12-14c took the store
+itself onto effects, so each is the store's own, with `Effect.orDie` where the
+rejected promise behind it was already a defect.
 
 P7-13 finished the boundary those pairs sit behind: a `GatewayMethodTable`
 entry is an `Effect<WireValue | undefined, GatewayRefusal>` rather than a
@@ -596,30 +596,34 @@ is run on the writer's own `ManagedRuntime` here. It is deleted once the host
 composer that holds it is a `Layer` able to hold that runtime itself, in
 Phase 7's devtrace composer conversion.
 
-`SettingsStore`'s `#readPersisted` and `#write` in
-`packages/host/src/settings-store.ts` are on the allowlist too, though not on
-`AgentTraceWriter`'s terms any more: `compose-settings.ts` is now an `Effect`
-over the `HostKernelTag`, `Environment`, `SecretCipher`, and
-`FileSystem.FileSystem` tags, so the class no longer builds its own
-`ManagedRuntime` over `NodeFileSystem.layer` — the composer captures the
-`Runtime.Runtime<FileSystem.FileSystem>` it is already running under, with
-`Effect.runtime`, and hands that in, so `readSettingsFileText` and
-`writeSettingsFileAtomic` run on the one `FileSystem` the host's assembly
-layer resolves rather than a second layer of the class's own. What keeps this
-on the allowlist is narrower now: the class still answers `get`/`set`/
-`snapshot`/... as Promises rather than Effects, so those two reads and writes
-still have to reach a promise somewhere, and this is where. The parse failure
-beside them, `parsePersistedSettingsEither`, answers an `Either` rather than a
-throw and is not on this allowlist, since it runs no effect: it wraps the
-store's own `parsePersistedSettingsThrowing` in `Either.try`, kept private to
-that wrapping rather than a second parse a caller could reach directly, and
-every caller today still folds a refusal into `defaultPersistedSettings()`
-exactly as the throwing form's catch already did. The cipher is sourced
+`SettingsStore` in `packages/host/src/settings-store.ts` is off the allowlist
+since P12-14c: its own methods are effects, `#readPersisted` and `#write`
+provide the `FileSystem` service the composer hands the class rather than
+running on a runtime it was handed, and the class holds no runtime at all.
+Its serialization moved with them and is Effect's own: the write gate and the
+read gate are two `Effect.unsafeMakeSemaphore(1)` permits in place of the two
+promise chains that stood there, so a second reader still waits for the first
+read rather than making its own, and a read that failed still leaves nothing
+held for the next one to inherit. The parse failure beside them,
+`parsePersistedSettingsEither`, answers an `Either` rather than a throw and
+never was on this allowlist, since it runs no effect. The cipher is sourced
 through the `SecretCipher` tag at the composer and handed to the class as the
 same plain field it always was: decrypting a stored key or grant is still
 synchronous and throws on its own terms, so widening the tag past the
-composer would gain the class nothing. The plan schedules no PR that states
-this class's own methods as Effects, and this row is where that is recorded.
+composer would gain the class nothing.
+
+`awaitedSettingsStore` in `packages/host/src/settings-store-awaited.ts` is
+what took the store's place on the allowlist, and it is the store's own
+methods as the promises their unmigrated callers still hold, run on the
+runtime the host is composed on. The callers are the reason it exists rather
+than the store: the calendars, observation, and live composers reach the
+store from promise-shaped bodies of their own, the settings composer's
+account-preferences and provider-key-vault chains are promise queues,
+`session-action-performer.ts` reads one field inside a promise, and
+`@sidecar/voice`'s `VoiceSettings` is a promise-shaped interface the
+capability assembler awaits — each its own conversion, and each one's landing
+takes rows out of this face. It is deleted by P12-14d..g, when the last of
+them yields the store directly.
 
 `tracedModelAdapter` in `packages/devtrace/src/brain-trace.ts` is on the same
 terms as `runCall`, permanently: the traced `respond` still answers the
@@ -1098,6 +1102,7 @@ design decision stated as such:
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | with the last promise-shaped hosted route (`conversation-read.ts`, `events.ts`, `devices-vault-app.ts`); P10-16 moved every route it converted onto `RateBrake.check` |
 | `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P12-15 — the fence must stay synchronous, so this is bookkeeping rather than a scheduled deletion |
 | `compose-account.ts`'s runs of the account gate's links on the host's own runtime | P7-13b | P12-14b |
+| `awaitedSettingsStore`, the settings store's own methods as the promises their unmigrated callers hold | P12-14c | P12-14d..g — the calendars, observation, and live composers, the settings composer's promise chains, the session action performer, and `@sidecar/voice`'s `VoiceSettings` |
 | `AppStateStore`'s `subscribe`, the Set-backed callback face beside `snapshot`/`update`/`touch` | P8-02 | P8-07 |
 | `LinearCredentials`'s renewal, running `singleFlightEffect` over a handed-in `Runtime` | P7-06 | once `LinearCredentials` answers an Effect itself |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08b |

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -119,15 +119,14 @@ export const composeAccount = (
 
     const session = new AccountSessionManager({
       client,
-      // The store answers promises still, so each of the session's three
-      // reads and writes of it is one lifted here rather than a run made
-      // there; the lateness of the links below is an `Effect.suspend` for the
-      // same reason, since a link read at construction would be read before
-      // `link()` has run.
+      // The store's own effects, with an I/O failure read as the defect the
+      // rejected promise behind each of these already was. The lateness of
+      // the links below is an `Effect.suspend` because a link read at
+      // construction would be read before `link()` has run.
       store: {
-        readAccount: () => Effect.promise(() => settings.store.readAccount()),
-        setAccount: (stored) => Effect.promise(() => settings.store.setAccount(stored)),
-        clearAccount: () => Effect.promise(() => settings.store.clearAccount()),
+        readAccount: () => Effect.orDie(settings.store.readAccount()),
+        setAccount: (stored) => Effect.orDie(settings.store.setAccount(stored)),
+        clearAccount: () => Effect.orDie(settings.store.clearAccount()),
       },
       hostedServiceBaseUrl: kernel.hostedServiceBaseUrl,
       requiresAccount: runMode.requiresAccount,
@@ -177,15 +176,11 @@ export const composeAccount = (
     }
 
     /**
-     * One account read, lifted from the store's own Promise into a
-     * never-failing Effect: a store that could not be read is an account
-     * this attempt cannot name, exactly as a rejected promise already read
-     * here before `accountBearer` gained an Effect of its own.
+     * One account read: a store that could not be read is an account this
+     * attempt cannot name, exactly as a rejected read already was here.
      */
     const readStoredAccount = (): Effect.Effect<StoredAccount | undefined> =>
-      Effect.tryPromise(() => settings.store.readAccount()).pipe(
-        Effect.orElseSucceed(() => undefined),
-      );
+      settings.store.readAccount().pipe(Effect.orElseSucceed(() => undefined));
 
     // The holder is the account's own address, so a call's one retry after a
     // 401 can tell a renewed token from a different person's: a sign-out and
@@ -201,7 +196,7 @@ export const composeAccount = (
     };
 
     const voiceCapabilities = new VoiceCapabilityAssembler({
-      settings: settings.store,
+      settings: settings.awaitedStore,
       credentialsUsable: () => runMode.sendsNetwork && capabilitiesActive(),
       fixtureRun: () => !runMode.sendsNetwork,
       accountSignedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
@@ -233,7 +228,7 @@ export const composeAccount = (
 
     async function sessionReplayState(): Promise<{ permitted: boolean; accountId?: string }> {
       const signedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
-      const accountId = signedIn ? (await settings.store.readAccount())?.id : undefined;
+      const accountId = signedIn ? (await settings.awaitedStore.readAccount())?.id : undefined;
       return {
         permitted: runMode.sendsNetwork && !sessionReplayEndedByDeletion,
         ...(accountId ? { accountId } : undefined),
@@ -328,7 +323,7 @@ export const composeAccount = (
       // its start alone and registers nothing to give back.
       lifetime: Effect.gen(function* () {
         account = runMode.requiresAccount
-          ? yield* Effect.promise(() => settings.store.accountSnapshot())
+          ? yield* Effect.orDie(settings.store.accountSnapshot())
           : { status: ACCOUNT_STATUS.SIGNED_OUT };
         session.initialize(account);
       }),

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -122,7 +122,7 @@ export const composeCalendars = (
     const runtime = yield* Effect.runtime<never>();
     const home = yield* cadenceHome;
     const { runMode, report, now } = kernel;
-    const settingsStore = settings.store;
+    const settingsStore = settings.awaitedStore;
     const late = yield* lateService<CalendarsLinks>();
     const links = (): CalendarsLinks => {
       const standing = late.unsafePeek();

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -277,9 +277,9 @@ export const hostAssemblyLayer: Layer.Layer<
         }),
       [GATEWAY_METHOD.CLIENT_BOOTSTRAP]: () =>
         Effect.gen(function* () {
-          const [snapshot, quiet, replay] = yield* Effect.promise(() =>
+          const snapshot = yield* Effect.orDie(settings.store.snapshot());
+          const [quiet, replay] = yield* Effect.promise(() =>
             Promise.all([
-              settings.store.snapshot(),
               account.capabilitiesActive()
                 ? calendars.announcementsQuietNow(now())
                 : Promise.resolve(false),
@@ -287,7 +287,7 @@ export const hostAssemblyLayer: Layer.Layer<
             ]),
           );
           const workspaceProjectDefaults = account.capabilitiesActive()
-            ? yield* Effect.promise(() =>
+            ? yield* Effect.orDie(
                 settings.store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
               )
             : undefined;

--- a/packages/host/src/compose-live.ts
+++ b/packages/host/src/compose-live.ts
@@ -200,7 +200,7 @@ export const composeLive = (
         .rosterForClients()
         .find((session) => session.status === SESSION_STATUS.WORKING);
       const talkKey = voiceHotkeyCandidates(
-        await settings.store.get(APP_SETTING_SCHEMA.voiceHotkey.field),
+        await settings.awaitedStore.get(APP_SETTING_SCHEMA.voiceHotkey.field),
       )[0];
       return {
         kind: PROACTIVE_SPEECH_KIND.ARRIVAL,

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -118,7 +118,7 @@ export const composeObservation = (
     const { settings, account, observationGate } = dependencies;
     const kernel = yield* HostKernelTag;
     const { runMode, report, now } = kernel;
-    const settingsStore = settings.store;
+    const settingsStore = settings.awaitedStore;
     const late = yield* lateService<ObservationLinks>();
     const links = (): ObservationLinks => {
       const standing = late.unsafePeek();

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -1,4 +1,4 @@
-import type * as FileSystem from "@effect/platform/FileSystem";
+import * as FileSystem from "@effect/platform/FileSystem";
 import {
   PRODUCT_EVENT,
   type ProductEventPropertiesFor,
@@ -43,6 +43,7 @@ import { heldProductEvents } from "./held-product-events.js";
 import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync.js";
 import { hostSettingSideEffects } from "./settings-side-effects.js";
 import { SettingsStore, type StoredAccount } from "./settings-store.js";
+import { type AwaitedSettingsStore, awaitedSettingsStore } from "./settings-store-awaited.js";
 import { reporterOf } from "./wire-helpers.js";
 
 type StoredSettings = SettingsUpdateResult["settings"]["stored"];
@@ -64,6 +65,12 @@ interface SettingsLinks {
 
 export interface SettingsComposer extends Composer {
   readonly store: SettingsStore;
+  /**
+   * The same store as the promises its unmigrated callers still hold.
+   *
+   * @deprecated See {@link AwaitedSettingsStore}; deleted by P12-14d..g.
+   */
+  readonly awaitedStore: AwaitedSettingsStore;
   readonly recordProductEvent: RecordProductEvent;
   /** One count per provider per day, as the observation pass makes it. */
   recordProductEventOncePerDay: ProductEventSender["recordOncePerDay"];
@@ -103,7 +110,8 @@ export const composeSettings = (): Effect.Effect<
     const identity = yield* AppIdentity;
     const overrides = yield* settingsOverrides;
     const runtime = yield* Effect.runtime<FileSystem.FileSystem>();
-    const fileSystem = yield* Effect.context<FileSystem.FileSystem>();
+    const fileSystemContext = yield* Effect.context<FileSystem.FileSystem>();
+    const fileSystem = yield* FileSystem.FileSystem;
     const { runMode, report } = kernel;
     const late = yield* lateService<SettingsLinks>();
     const links = (): SettingsLinks => {
@@ -121,17 +129,17 @@ export const composeSettings = (): Effect.Effect<
       credentialsUsable: runMode.observesProviders,
       cipher,
       overrides,
-      runtime,
+      fileSystem,
     });
+    const awaitedStore = awaitedSettingsStore(store, runtime);
 
     /**
-     * One account read, lifted from the store's own Promise into a
-     * never-failing Effect: a store that could not be read is an account
-     * this attempt cannot name, exactly as a rejected promise already read
-     * here before `accountBearer` gained an Effect of its own.
+     * One account read: a store that could not be read is an account this
+     * attempt cannot name, which is what every caller of this already treated
+     * a failed read as.
      */
     const readStoredAccount = (): Effect.Effect<StoredAccount | undefined> =>
-      Effect.tryPromise(() => store.readAccount()).pipe(Effect.orElseSucceed(() => undefined));
+      store.readAccount().pipe(Effect.orElseSucceed(() => undefined));
 
     // The quit's drain flushes ahead of this composer's stop, so a batch no
     // account could carry at that flush is on disk before the queue is dropped.
@@ -142,7 +150,7 @@ export const composeSettings = (): Effect.Effect<
       readAccessToken: () => Effect.map(readStoredAccount(), (account) => account?.accessToken),
       refreshAccount: () => links().refreshAccount(),
       readAccountKey: () => Effect.map(readStoredAccount(), (account) => account?.email),
-      held: heldProductEvents(kernel.stateRoot, report, fileSystem),
+      held: heldProductEvents(kernel.stateRoot, report, fileSystemContext),
     });
     const hostedVault = new HostedVaultClient({
       serviceBaseUrl: kernel.hostedServiceBaseUrl,
@@ -167,17 +175,17 @@ export const composeSettings = (): Effect.Effect<
     });
     const vaultSync = new ProviderKeyVaultSync({
       vault: hostedVault,
-      readStoredApiKey: (providerId) => store.readStoredApiKey(providerId),
+      readStoredApiKey: (providerId) => awaitedStore.readStoredApiKey(providerId),
       account: async () => {
-        const held = await store.readAccount();
+        const held = await awaitedStore.readAccount();
         if (!held) return undefined;
         const vaultAccount: VaultSyncAccount = { email: held.email };
         if (held.id) vaultAccount.id = held.id;
         return vaultAccount;
       },
       tenant: {
-        read: () => store.readVaultSyncAccount(),
-        write: (accountKey) => store.setVaultSyncAccount(accountKey),
+        read: () => awaitedStore.readVaultSyncAccount(),
+        write: (accountKey) => awaitedStore.setVaultSyncAccount(accountKey),
       },
     });
 
@@ -185,7 +193,7 @@ export const composeSettings = (): Effect.Effect<
     let accountPreferencesSync: Promise<void> = Promise.resolve();
 
     function reconcileProviderKeyVault(): void {
-      void store
+      void awaitedStore
         .snapshot()
         .then((settings) =>
           settings.stored.syncProviderKeys ? vaultSync.apply(true, { claim: false }) : undefined,
@@ -193,7 +201,7 @@ export const composeSettings = (): Effect.Effect<
     }
 
     async function readAccountPreferenceAccountKey(): Promise<string | undefined> {
-      return (await store.readAccount())?.email;
+      return (await awaitedStore.readAccount())?.email;
     }
 
     function queueAccountPreferencesSync(label: string, work: () => Promise<void>): Promise<void> {
@@ -220,10 +228,10 @@ export const composeSettings = (): Effect.Effect<
     async function accountPreferenceHydrationBaseline(
       accountEmail: string,
     ): Promise<AccountPreferences> {
-      const baseline = await store.accountPreferencesSyncBaseline(accountEmail);
+      const baseline = await awaitedStore.accountPreferencesSyncBaseline(accountEmail);
       if (baseline !== undefined) return baseline;
-      const preferences = await store.accountPreferences();
-      await store.setAccountPreferencesSyncBaseline(accountEmail, preferences);
+      const preferences = await awaitedStore.accountPreferences();
+      await awaitedStore.setAccountPreferencesSyncBaseline(accountEmail, preferences);
       return preferences;
     }
 
@@ -253,26 +261,26 @@ export const composeSettings = (): Effect.Effect<
       if (!remote || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
 
       if (!remote.hasStoredSnapshot) {
-        const preferences = await store.accountPreferences();
+        const preferences = await awaitedStore.accountPreferences();
         if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
         if (!accountPreferencesEmpty(preferences)) {
           const written = await accountPreferencesClient.writePreferences(preferences);
           if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
         }
-        if (!(await store.setAccountPreferencesSyncBaseline(accountKey, preferences))) {
+        if (!(await awaitedStore.setAccountPreferencesSyncBaseline(accountKey, preferences))) {
           return false;
         }
         accountPreferencesHydratedAccount = accountKey;
         return true;
       }
 
-      const saved = await store.applyAccountPreferences(remote.preferences, {
+      const saved = await awaitedStore.applyAccountPreferences(remote.preferences, {
         accountEmail: accountKey,
         preferences: baseline,
       });
       if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
       accountPreferencesHydratedAccount = accountKey;
-      const preferences = await store.accountPreferences();
+      const preferences = await awaitedStore.accountPreferences();
       if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
       if (saved.changed.length > 0) {
         await applyAccountPreferenceSideEffects(saved, saved.changed);
@@ -281,7 +289,7 @@ export const composeSettings = (): Effect.Effect<
         const written = await accountPreferencesClient.writePreferences(preferences);
         if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return true;
       }
-      await store.setAccountPreferencesSyncBaseline(accountKey, preferences);
+      await awaitedStore.setAccountPreferencesSyncBaseline(accountKey, preferences);
       return true;
     }
 
@@ -295,7 +303,7 @@ export const composeSettings = (): Effect.Effect<
         ) {
           return;
         }
-        const preferences = await store.accountPreferences();
+        const preferences = await awaitedStore.accountPreferences();
         if (
           (await readAccountPreferenceAccountKey()) !== accountKey ||
           accountPreferencesHydratedAccount !== accountKey
@@ -304,7 +312,7 @@ export const composeSettings = (): Effect.Effect<
         }
         const written = await accountPreferencesClient.writePreferences(preferences);
         if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return;
-        await store.setAccountPreferencesSyncBaseline(accountKey, preferences);
+        await awaitedStore.setAccountPreferencesSyncBaseline(accountKey, preferences);
       });
     }
 
@@ -322,7 +330,7 @@ export const composeSettings = (): Effect.Effect<
     }
 
     async function emitSettings(): Promise<void> {
-      emitSettingsSnapshot(await store.snapshot());
+      emitSettingsSnapshot(await awaitedStore.snapshot());
     }
 
     function recordSettingUpdate(
@@ -371,7 +379,7 @@ export const composeSettings = (): Effect.Effect<
 
     const refusedSettings = async (reason: string): Promise<SettingsUpdateResult> => ({
       status: ACTION_RESULT_STATUS.REJECTED,
-      settings: await store.snapshot(),
+      settings: await awaitedStore.snapshot(),
       reason,
     });
 
@@ -395,10 +403,9 @@ export const composeSettings = (): Effect.Effect<
 
     const methods: GatewayMethodTable = {
       [GATEWAY_METHOD.SETTINGS_SNAPSHOT]: () =>
-        Effect.map(
-          Effect.promise(() => store.snapshot()),
-          (snapshot) => ({ settings: carried(snapshot) }),
-        ),
+        Effect.map(Effect.orDie(store.snapshot()), (snapshot) => ({
+          settings: carried(snapshot),
+        })),
       [GATEWAY_METHOD.SETTINGS_UPDATE]: (params) =>
         Effect.gen(function* () {
           const field = params.field;
@@ -409,7 +416,7 @@ export const composeSettings = (): Effect.Effect<
           if (!parsed.valid) return yield* invalid("value is not the shape that setting takes");
           const result = yield* Effect.promise(() =>
             settingsWrite(
-              () => store.set(field, parsed.value),
+              () => awaitedStore.set(field, parsed.value),
               async (saved) => {
                 if (saved.reason) return;
                 recordSettingUpdate(field, saved.settings);
@@ -445,7 +452,8 @@ export const composeSettings = (): Effect.Effect<
           const result = yield* Effect.promise(() =>
             settingsWrite(
               // SAFETY: settingEntryGuard validated the entry before it reaches the store.
-              () => store.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
+              () =>
+                awaitedStore.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
               async (saved) => {
                 if (saved.reason) return;
                 recordSettingUpdate(field, saved.settings);
@@ -465,7 +473,7 @@ export const composeSettings = (): Effect.Effect<
             return yield* invalid("scope is not one this build knows");
           const result = yield* Effect.promise(() =>
             settingsWrite(
-              () => store.resetSettings(scope),
+              () => awaitedStore.resetSettings(scope),
               async (saved) => {
                 if (saved.reason) return;
                 recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
@@ -493,7 +501,7 @@ export const composeSettings = (): Effect.Effect<
           }
           const result = yield* Effect.promise(() =>
             settingsWrite(
-              () => store.setApiKey(providerId, apiKey),
+              () => awaitedStore.setApiKey(providerId, apiKey),
               async (saved) => {
                 if (saved.reason) return;
                 if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
@@ -533,6 +541,7 @@ export const composeSettings = (): Effect.Effect<
     return {
       methods,
       store,
+      awaitedStore,
       recordProductEvent,
       recordProductEventOncePerDay: (name, key, properties) =>
         productEvents.recordOncePerDay(name, key, properties),
@@ -552,7 +561,7 @@ export const composeSettings = (): Effect.Effect<
       },
       lifetime: startedAndStopped(
         Effect.sync(() => {
-          void store.snapshot();
+          void awaitedStore.snapshot();
           productEvents.arm();
           productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: identity.appVersion });
           productEvents.markDayActive();

--- a/packages/host/src/session-action-performer.test.ts
+++ b/packages/host/src/session-action-performer.test.ts
@@ -31,7 +31,7 @@ import { Effect } from "effect";
 import { test } from "vitest";
 import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
 import { createSessionActionPerformer } from "./session-action-performer.js";
-import type { SettingsStore } from "./settings-store.js";
+import type { AwaitedSettingsStore } from "./settings-store-awaited.js";
 
 /** Waits for a real condition to become true, ticking Effect's own scheduler rather than a fixed drain. */
 function waitFor(condition: () => boolean, rounds = 300): Effect.Effect<void> {
@@ -108,14 +108,14 @@ function heldSettings(stored?: Readonly<Record<string, WorkspaceAgentSelection>>
   // SAFETY: the performer reads one field here, workspaceAgentDefaults, and
   // the pairing table is a legal value of it; the generic signature is
   // satisfied for that one field.
-  const store: Pick<SettingsStore, "get"> = {
+  const store: Pick<AwaitedSettingsStore, "get"> = {
     get: (async () => {
       reads += 1;
       await new Promise<void>((resolve) => {
         release = resolve;
       });
       return stored;
-    }) as SettingsStore["get"],
+    }) as AwaitedSettingsStore["get"],
   };
   return { store, release: () => release?.(), reads: () => reads };
 }
@@ -123,7 +123,7 @@ function heldSettings(stored?: Readonly<Record<string, WorkspaceAgentSelection>>
 interface FixtureOptions {
   outcome?: HostedActionOutcome;
   creation?: HostedActionWorkspaceOutcome;
-  settingsStore?: Pick<SettingsStore, "get">;
+  settingsStore?: Pick<AwaitedSettingsStore, "get">;
   openExternal?: (url: string, kind: HostNodeOpenKind) => Promise<void>;
   sendsNetwork?: boolean;
 }
@@ -171,7 +171,7 @@ function fixture(options: FixtureOptions = {}) {
     // an undefined answer is a legal value of it; the generic signature is
     // satisfied for that one field.
     settingsStore: options.settingsStore ?? {
-      get: (async () => undefined) as SettingsStore["get"],
+      get: (async () => undefined) as AwaitedSettingsStore["get"],
     },
     rememberWorkspaceDefaults: async (...remembered) => {
       recorded.remembered.push(remembered);

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -35,7 +35,7 @@ import {
   settleHostedWrite,
 } from "./hosted-action-result.js";
 import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
-import type { SettingsStore } from "./settings-store.js";
+import type { AwaitedSettingsStore } from "./settings-store-awaited.js";
 
 /**
  * An open that was handed to the native node and whose answer was lost with
@@ -82,7 +82,7 @@ export interface SessionActionPerformerDependencies {
   /** Draws the roster again, so a write that moved a session is seen rather than remembered. */
   refreshSessions: () => Promise<void>;
   sendsNetwork: boolean;
-  settingsStore: Pick<SettingsStore, "get">;
+  settingsStore: Pick<AwaitedSettingsStore, "get">;
   rememberWorkspaceDefaults: (
     providerId: CloudAgentProviderId,
     providerProjectId: string,

--- a/packages/host/src/settings-store-awaited.ts
+++ b/packages/host/src/settings-store-awaited.ts
@@ -1,0 +1,140 @@
+import type { CalendarAccountCredential } from "@sidecar/calendar";
+import type { CredentialProviderId } from "@sidecar/credentials";
+import type { AccountSnapshot } from "@sidecar/credentials/snapshot";
+import type {
+  AccountPreferenceField,
+  AccountPreferences,
+  AppSettingField,
+  AppSettingValue,
+  KeyedAppSettingField,
+  SettingEntryValue,
+} from "@sidecar/settings";
+import type {
+  AppSettings,
+  SettingsResetScope,
+  SettingsUpdateResult,
+  VoiceSource,
+} from "@sidecar/settings/wire";
+import { type Effect, Runtime } from "effect";
+import type { AppleCalendarConnection } from "./apple-calendar.js";
+import type { SettingsStore, StoredAccount } from "./settings-store.js";
+
+/**
+ * The settings store's own methods, as the Promises the callers that have not
+ * migrated still hold. Every method here is the store's effect run on the
+ * runtime the host is composed on, so nothing reaches for an ambient default
+ * one, and no read or write behaves differently from the one a migrated
+ * caller yields.
+ *
+ * @deprecated The strangler shim on the `docs/adr/0001-effect.md` allowlist,
+ * standing in for the callers this PR did not take: the calendars,
+ * observation, and live composers, the settings composer's own
+ * account-preferences and vault chains, the session action performer, and
+ * `@sidecar/voice`'s `VoiceSettings`, each a promise-shaped collaborator whose
+ * conversion is its own change. It is deleted by P12-14d..g as each of those
+ * moves onto the store itself.
+ */
+export interface AwaitedSettingsStore {
+  get<Field extends AppSettingField>(field: Field): Promise<AppSettingValue<Field>>;
+  set<Field extends AppSettingField>(
+    field: Field,
+    value: AppSettingValue<Field>,
+  ): Promise<SettingsUpdateResult>;
+  setEntry<Field extends KeyedAppSettingField>(
+    field: Field,
+    key: string,
+    value: SettingEntryValue<Field> | undefined,
+  ): Promise<SettingsUpdateResult>;
+  clearEntryIfUnchanged<Field extends KeyedAppSettingField>(
+    field: Field,
+    key: string,
+    expected: SettingEntryValue<Field>,
+  ): Promise<SettingsUpdateResult & { cleared: boolean }>;
+  snapshot(): Promise<AppSettings>;
+  resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult>;
+  readAccount(): Promise<StoredAccount | undefined>;
+  setAccount(account: StoredAccount): Promise<AccountSnapshot>;
+  clearAccount(): Promise<AccountSnapshot>;
+  accountSnapshot(): Promise<AccountSnapshot>;
+  accountPreferences(): Promise<AccountPreferences>;
+  applyAccountPreferences(
+    settings: AccountPreferences,
+    expected?: { accountEmail: string; preferences: AccountPreferences },
+  ): Promise<SettingsUpdateResult & { changed: readonly AccountPreferenceField[] }>;
+  accountPreferencesSyncBaseline(accountEmail: string): Promise<AccountPreferences | undefined>;
+  setAccountPreferencesSyncBaseline(
+    accountEmail: string,
+    preferences: AccountPreferences,
+  ): Promise<boolean>;
+  readVoiceSource(): Promise<VoiceSource>;
+  readApiKey(providerId: CredentialProviderId): Promise<string | undefined>;
+  readStoredApiKey(providerId: CredentialProviderId): Promise<string | undefined>;
+  setApiKey(
+    providerId: CredentialProviderId,
+    apiKey: string | undefined,
+  ): Promise<SettingsUpdateResult>;
+  readVaultSyncAccount(): Promise<string | undefined>;
+  setVaultSyncAccount(accountKey: string): Promise<void>;
+  readCalendarAccounts(): Promise<readonly CalendarAccountCredential[]>;
+  addCalendarAccount(
+    accountId: string,
+    refreshToken: string,
+    selectedCalendarIds: readonly string[],
+  ): Promise<SettingsUpdateResult>;
+  removeCalendarAccount(accountId: string): Promise<SettingsUpdateResult>;
+  setCalendarSelected(
+    accountId: string,
+    calendarId: string,
+    selected: boolean,
+  ): Promise<SettingsUpdateResult>;
+  connectAppleCalendar(selectedCalendarIds: readonly string[]): Promise<SettingsUpdateResult>;
+  disconnectAppleCalendar(): Promise<SettingsUpdateResult>;
+  calendarConnectionStored(): Promise<boolean>;
+  readAppleCalendarConnection(): Promise<AppleCalendarConnection | undefined>;
+}
+
+/** @deprecated See {@link AwaitedSettingsStore}; deleted by P12-14d..g. */
+export function awaitedSettingsStore(
+  store: SettingsStore,
+  runtime: Runtime.Runtime<never>,
+): AwaitedSettingsStore {
+  const awaited = <Value>(effect: Effect.Effect<Value, unknown>): Promise<Value> =>
+    Runtime.runPromise(runtime)(effect);
+  return {
+    get: (field) => awaited(store.get(field)),
+    set: (field, value) => awaited(store.set(field, value)),
+    setEntry: (field, key, value) => awaited(store.setEntry(field, key, value)),
+    clearEntryIfUnchanged: (field, key, expected) =>
+      awaited(store.clearEntryIfUnchanged(field, key, expected)),
+    snapshot: () => awaited(store.snapshot()),
+    resetSettings: (scope) => awaited(store.resetSettings(scope)),
+    readAccount: () => awaited(store.readAccount()),
+    setAccount: (account) => awaited(store.setAccount(account)),
+    clearAccount: () => awaited(store.clearAccount()),
+    accountSnapshot: () => awaited(store.accountSnapshot()),
+    accountPreferences: () => awaited(store.accountPreferences()),
+    applyAccountPreferences: (settings, expected) =>
+      awaited(store.applyAccountPreferences(settings, expected)),
+    accountPreferencesSyncBaseline: (accountEmail) =>
+      awaited(store.accountPreferencesSyncBaseline(accountEmail)),
+    setAccountPreferencesSyncBaseline: (accountEmail, preferences) =>
+      awaited(store.setAccountPreferencesSyncBaseline(accountEmail, preferences)),
+    readVoiceSource: () => awaited(store.readVoiceSource()),
+    readApiKey: (providerId) => awaited(store.readApiKey(providerId)),
+    readStoredApiKey: (providerId) => awaited(store.readStoredApiKey(providerId)),
+    setApiKey: (providerId, apiKey) => awaited(store.setApiKey(providerId, apiKey)),
+    readVaultSyncAccount: () => awaited(store.readVaultSyncAccount()),
+    setVaultSyncAccount: (accountKey) => awaited(store.setVaultSyncAccount(accountKey)),
+    readCalendarAccounts: () => awaited(store.readCalendarAccounts()),
+    addCalendarAccount: (accountId, refreshToken, selectedCalendarIds) =>
+      awaited(store.addCalendarAccount(accountId, refreshToken, selectedCalendarIds)),
+    removeCalendarAccount: (accountId) => awaited(store.removeCalendarAccount(accountId)),
+    setCalendarSelected: (accountId, calendarId, selected) =>
+      awaited(store.setCalendarSelected(accountId, calendarId, selected)),
+    connectAppleCalendar: (selectedCalendarIds) =>
+      awaited(store.connectAppleCalendar(selectedCalendarIds)),
+    disconnectAppleCalendar: () => awaited(store.disconnectAppleCalendar()),
+    calendarConnectionStored: () => awaited(store.calendarConnectionStored()),
+    readAppleCalendarConnection: () => awaited(store.readAppleCalendarConnection()),
+  };
+}

--- a/packages/host/src/settings-store.test.ts
+++ b/packages/host/src/settings-store.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type * as FileSystem from "@effect/platform/FileSystem";
+import * as FileSystem from "@effect/platform/FileSystem";
 import { NodeFileSystem } from "@effect/platform-node";
+import { it } from "@effect/vitest";
 import { CREDENTIAL_PROVIDER_ID, type CredentialProviderId } from "@sidecar/credentials";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "@sidecar/credentials/vocabulary";
 import { LIVE_DEFAULTS, LIVE_VOICE } from "@sidecar/live";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
 import {
   PROVIDER_ID,
   type ProviderId,
@@ -24,9 +26,14 @@ import {
 } from "@sidecar/settings";
 import { appSettingsView, SETTINGS_RESET_SCOPE, VOICE_SOURCE } from "@sidecar/settings/wire";
 import { PANEL_FORM_FACTOR } from "@sidecar/surface";
-import { type UnparsedWireValue, unparsedWire, type WireRecord } from "@sidecar/wire";
+import {
+  ACTION_RESULT_STATUS,
+  type UnparsedWireValue,
+  unparsedWire,
+  type WireRecord,
+} from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
-import { ConfigProvider, Effect, Layer, type Runtime } from "effect";
+import { ConfigProvider, Effect, Layer, Runtime } from "effect";
 import { test } from "vitest";
 import { Environment } from "./effect/seams.js";
 import {
@@ -39,6 +46,7 @@ import {
   SettingsStore,
   type SettingsStoreOptions,
 } from "./settings-store.js";
+import { type AwaitedSettingsStore, awaitedSettingsStore } from "./settings-store-awaited.js";
 
 const TEST_API_KEY = "conductor-live-key";
 const SETTINGS_FILE_NAME = "settings.json";
@@ -117,10 +125,18 @@ function expectedPersistedSettings(overrides: WireRecord = {}): UnparsedWireValu
   );
 }
 
-/** The runtime `#readPersisted`/`#write` run their `FileSystem` effects on, built once for every store this suite opens. */
-const FILE_SYSTEM_RUNTIME: Runtime.Runtime<FileSystem.FileSystem> = Effect.runSync(
-  Effect.provide(Effect.runtime<FileSystem.FileSystem>(), NodeFileSystem.layer),
+/** The file system every store this suite opens reads and writes through. */
+const FILE_SYSTEM: FileSystem.FileSystem = Effect.runSync(
+  Effect.provide(FileSystem.FileSystem, NodeFileSystem.layer),
 );
+
+/**
+ * The runtime the awaited face below runs the store's effects on. The store's
+ * own methods are effects; this suite holds them as the promises its
+ * assertions are written against, which is the same face the callers that
+ * have not migrated hold.
+ */
+const RUNTIME: Runtime.Runtime<never> = Runtime.defaultRuntime;
 
 function overridesFor(environment: NodeJS.ProcessEnv): SettingsEnvironmentOverrides {
   const entries = Object.entries(environment).filter(
@@ -137,14 +153,14 @@ function overridesFor(environment: NodeJS.ProcessEnv): SettingsEnvironmentOverri
 function storeIn(
   directory: string,
   options: { cipher?: SecretCipher; environment?: NodeJS.ProcessEnv } = {},
-): SettingsStore {
+): AwaitedSettingsStore {
   const config: SettingsStoreOptions = {
     directory: () => directory,
     cipher: options.cipher ?? testCipher(),
     overrides: overridesFor(options.environment ?? {}),
-    runtime: FILE_SYSTEM_RUNTIME,
+    fileSystem: FILE_SYSTEM,
   };
-  return new SettingsStore(config);
+  return awaitedSettingsStore(new SettingsStore(config), RUNTIME);
 }
 
 test("a failed first load is retried before a later write", async (t) => {
@@ -158,18 +174,21 @@ test("a failed first load is retried before a later write", async (t) => {
     }),
   );
   let directoryReads = 0;
-  const store = new SettingsStore({
-    directory: () => {
-      directoryReads += 1;
-      if (directoryReads === 1) {
-        throw Object.assign(new Error("permission denied"), { code: "EACCES" });
-      }
-      return directory;
-    },
-    cipher: testCipher(),
-    overrides: overridesFor({}),
-    runtime: FILE_SYSTEM_RUNTIME,
-  });
+  const store = awaitedSettingsStore(
+    new SettingsStore({
+      directory: () => {
+        directoryReads += 1;
+        if (directoryReads === 1) {
+          throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+        }
+        return directory;
+      },
+      cipher: testCipher(),
+      overrides: overridesFor({}),
+      fileSystem: FILE_SYSTEM,
+    }),
+    RUNTIME,
+  );
 
   await assert.rejects(store.get(APP_SETTING_SCHEMA.showInDock.field), /permission denied/);
   await store.set(APP_SETTING_SCHEMA.duckOtherMedia.field, false);
@@ -180,24 +199,24 @@ test("a failed first load is retried before a later write", async (t) => {
   assert.equal(await reopened.get(APP_SETTING_SCHEMA.duckOtherMedia.field), false);
 });
 
-async function readWorkspaceAgentDefault(store: SettingsStore, providerId: ProviderId) {
+async function readWorkspaceAgentDefault(store: AwaitedSettingsStore, providerId: ProviderId) {
   return (await store.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId];
 }
 
 async function setWorkspaceAgentDefault(
-  store: SettingsStore,
+  store: AwaitedSettingsStore,
   providerId: ProviderId,
   selection: WorkspaceAgentSelection | undefined,
 ) {
   return store.setEntry(APP_SETTING_SCHEMA.workspaceAgentDefaults.field, providerId, selection);
 }
 
-async function readWorkspaceProjectDefault(store: SettingsStore, providerId: ProviderId) {
+async function readWorkspaceProjectDefault(store: AwaitedSettingsStore, providerId: ProviderId) {
   return (await store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field))?.[providerId];
 }
 
 async function setWorkspaceProjectDefault(
-  store: SettingsStore,
+  store: AwaitedSettingsStore,
   providerId: ProviderId,
   providerProjectId: string | undefined,
 ) {
@@ -1597,3 +1616,68 @@ test("pasting a key back while parked on the allowance is still choosing it", as
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.KEY);
 });
+
+/**
+ * The store's own face, yielded rather than awaited: what every caller above
+ * reads through one run apiece is one fiber here, and a write and the read
+ * after it settle in the order the effects are sequenced in.
+ */
+it.effect("the store's own methods are effects a caller sequences itself", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const directory = yield* temporaryDirectoryScoped();
+      const store = new SettingsStore({
+        directory: () => directory,
+        cipher: testCipher(),
+        overrides: overridesFor({}),
+        fileSystem: FILE_SYSTEM,
+      });
+
+      assert.equal(
+        yield* store.get(APP_SETTING_SCHEMA.showInDock.field),
+        APP_SETTING_SCHEMA.showInDock.guard(undefined).value,
+      );
+      const saved = yield* store.set(APP_SETTING_SCHEMA.showInDock.field, true);
+      assert.equal(saved.status, ACTION_RESULT_STATUS.ACCEPTED);
+      assert.equal(yield* store.get(APP_SETTING_SCHEMA.showInDock.field), true);
+
+      const reopened = new SettingsStore({
+        directory: () => directory,
+        cipher: testCipher(),
+        overrides: overridesFor({}),
+        fileSystem: FILE_SYSTEM,
+      });
+      assert.equal(yield* reopened.get(APP_SETTING_SCHEMA.showInDock.field), true);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
+
+/** Concurrent reads share one read of the file rather than each making their own. */
+it.effect("concurrent reads of an unread store read the file once", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const directory = yield* temporaryDirectoryScoped();
+      let directoryReads = 0;
+      const store = new SettingsStore({
+        directory: () => {
+          directoryReads += 1;
+          return directory;
+        },
+        cipher: testCipher(),
+        overrides: overridesFor({}),
+        fileSystem: FILE_SYSTEM,
+      });
+
+      yield* Effect.all(
+        [
+          store.get(APP_SETTING_SCHEMA.showInDock.field),
+          store.get(APP_SETTING_SCHEMA.duckOtherMedia.field),
+          store.get(APP_SETTING_SCHEMA.voice.field),
+        ],
+        { concurrency: 3 },
+      );
+
+      assert.equal(directoryReads, 1);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);

--- a/packages/host/src/settings-store.ts
+++ b/packages/host/src/settings-store.ts
@@ -1,4 +1,5 @@
-import type * as FileSystem from "@effect/platform/FileSystem";
+import type { PlatformError } from "@effect/platform/Error";
+import * as FileSystem from "@effect/platform/FileSystem";
 import { APPLE_CALENDAR_ID } from "@sidecar/calendar/vocabulary";
 import {
   CREDENTIAL_PROVIDER_LIST,
@@ -39,7 +40,7 @@ import {
   type WireRecord,
   type WireValue,
 } from "@sidecar/wire";
-import { Either, Redacted, Runtime } from "effect";
+import { Effect, Either, Redacted } from "effect";
 // The reader owns the shape it is fed: what this store resolves a stored
 // connection into is exactly what `readAppleCalendarConnection` promises it.
 import type { AppleCalendarConnection } from "./apple-calendar.js";
@@ -122,12 +123,13 @@ export interface SettingsStoreOptions {
    */
   credentialsUsable?: boolean;
   /**
-   * What `#readPersisted` and `#write` below run their `FileSystem` effects
-   * on: the composer's own runtime, captured once with `Effect.runtime` over
-   * the `FileSystem` the host's assembly layer already resolves, rather than a
-   * `FileSystem` layer this class stands up for itself.
+   * The file system `#readPersisted` and `#write` below reach the settings
+   * file through, resolved once by the composer from the host's own assembly
+   * rather than by a layer this class stands up for itself. It is the service
+   * and not a runtime, so every method here is an effect with nothing left in
+   * its context for a caller to provide.
    */
-  runtime: Runtime.Runtime<FileSystem.FileSystem>;
+  fileSystem: FileSystem.FileSystem;
 }
 
 export interface PersistedSettings extends StoredAppSettings {
@@ -491,43 +493,48 @@ export class SettingsStore {
   readonly #cipher: SecretCipher;
   readonly #overrides: SettingsEnvironmentOverrides;
   readonly #credentialsUsable: boolean;
+  readonly #fileSystem: FileSystem.FileSystem;
   /**
-   * The runtime `#readPersisted` and `#write` below run their `FileSystem`
-   * effects on: the composer's own, handed in rather than a layer this class
-   * stands up for itself.
-   *
-   * @deprecated The strangler shim on the `docs/adr/0001-effect.md` allowlist:
-   * this class still answers `get`/`set`/`snapshot`/... as Promises rather
-   * than Effects, so its own `FileSystem` reads and writes still have to be
-   * run to a promise somewhere, and this is where. It goes once the store's
-   * own methods are stated as Effects, which the plan does not currently
-   * schedule; this is where that is recorded.
+   * The settings as last read or written. The gate beside it is what makes a
+   * read shared rather than repeated: a second reader waits for the first
+   * read to land and then finds it here, and a read that failed leaves
+   * nothing behind, so the next reader tries the file again.
    */
-  readonly #runtime: Runtime.Runtime<FileSystem.FileSystem>;
-  #loading: Promise<PersistedSettings> | undefined;
+  #held: PersistedSettings | undefined;
+  readonly #reads = Effect.unsafeMakeSemaphore(1);
   #resolved = new Map<CredentialProviderId, ResolvedApiKey>();
   /** Decrypted accounts, cached like the keys so timers never drum the Keychain. */
   #resolvedCalendarAccounts: readonly CalendarAccountCredential[] | undefined;
-  #mutations: Promise<void> = Promise.resolve();
+  /**
+   * Runs one settings change at a time. Serializing only the file write is not
+   * enough: a user with more than one provider row can start a second save
+   * before the first lands, and both would read the same stored keys before
+   * either wrote, so the later write would drop the other provider's key.
+   */
+  readonly #writes = Effect.unsafeMakeSemaphore(1);
 
-  async get<Field extends AppSettingField>(field: Field): Promise<AppSettingValue<Field>> {
+  get<Field extends AppSettingField>(
+    field: Field,
+  ): Effect.Effect<AppSettingValue<Field>, PlatformError> {
     // SAFETY: PersistedSettings extends the schema-derived stored shape; the
     // generic field selects the same schema member on both sides.
-    return (await this.#load())[field] as AppSettingValue<Field>;
+    return Effect.map(this.#load(), (persisted) => persisted[field] as AppSettingValue<Field>);
   }
 
-  async set<Field extends AppSettingField>(
+  set<Field extends AppSettingField>(
     field: Field,
     value: AppSettingValue<Field>,
-  ): Promise<SettingsUpdateResult> {
-    await this.#mutate((persisted) => {
-      if (persisted[field] === value) return undefined;
-      const next: PersistedSettings = { ...persisted };
-      if (value === undefined) delete next[field];
-      else Object.assign(next, { [field]: value });
-      return next;
+  ): Effect.Effect<SettingsUpdateResult, PlatformError> {
+    return Effect.gen(this, function* () {
+      yield* this.#mutate((persisted) => {
+        if (persisted[field] === value) return undefined;
+        const next: PersistedSettings = { ...persisted };
+        if (value === undefined) delete next[field];
+        else Object.assign(next, { [field]: value });
+        return next;
+      });
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: yield* this.snapshot() };
     });
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
   /**
@@ -538,112 +545,125 @@ export class SettingsStore {
    * left with no entries is deleted, so an emptied setting reads as unset
    * rather than as an empty object.
    */
-  async setEntry<Field extends KeyedAppSettingField>(
+  setEntry<Field extends KeyedAppSettingField>(
     field: Field,
     key: string,
     value: SettingEntryValue<Field> | undefined,
-  ): Promise<SettingsUpdateResult> {
+  ): Effect.Effect<SettingsUpdateResult, PlatformError> {
     // SAFETY: a setting entry's own value is one of the wire values it was parsed from.
     const entry = value as UnparsedWireValue;
-    await this.#mutate((persisted) => {
-      // SAFETY: KeyedAppSettingField identifies fields whose stored value is a wire record.
-      const current = persisted[field] as WireRecord | undefined;
-      if (sameSettingEntry(field, current?.[key], entry)) return undefined;
-      const entries = { ...current };
-      if (entry === undefined) delete entries[key];
-      else entries[key] = entry;
-      const next: PersistedSettings = { ...persisted };
-      if (Object.keys(entries).length > 0) Object.assign(next, { [field]: entries });
-      else delete next[field];
-      return next;
+    return Effect.gen(this, function* () {
+      yield* this.#mutate((persisted) => {
+        // SAFETY: KeyedAppSettingField identifies fields whose stored value is a wire record.
+        const current = persisted[field] as WireRecord | undefined;
+        if (sameSettingEntry(field, current?.[key], entry)) return undefined;
+        const entries = { ...current };
+        if (entry === undefined) delete entries[key];
+        else entries[key] = entry;
+        const next: PersistedSettings = { ...persisted };
+        if (Object.keys(entries).length > 0) Object.assign(next, { [field]: entries });
+        else delete next[field];
+        return next;
+      });
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: yield* this.snapshot() };
     });
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
-  async accountPreferences(): Promise<AccountPreferences> {
-    return accountPreferencesFromPersisted(await this.#load());
+  accountPreferences(): Effect.Effect<AccountPreferences, PlatformError> {
+    return Effect.map(this.#load(), accountPreferencesFromPersisted);
   }
 
-  async applyAccountPreferences(
+  applyAccountPreferences(
     settings: AccountPreferences,
     expected?: { accountEmail: string; preferences: AccountPreferences },
-  ): Promise<SettingsUpdateResult & { changed: readonly AccountPreferenceField[] }> {
-    const changed: AccountPreferenceField[] = [];
-    await this.#mutate((persisted) => {
-      if (expected && persisted.account?.email !== expected.accountEmail) return undefined;
-      const nextSettings = expected
-        ? accountPreferencesWithLocalChanges(
-            settings,
-            accountPreferencesFromPersisted(persisted),
-            expected.preferences,
-          )
-        : settings;
-      const next: PersistedSettings = { ...persisted };
-      for (const field of ACCOUNT_PREFERENCE_FIELDS) {
-        // SAFETY: AccountPreferences is the parsed subset of JSON-compatible stored app settings.
-        const value = nextSettings[field] as UnparsedWireValue;
-        // SAFETY: AccountPreferenceField selects the same persisted JSON-compatible setting value.
-        if (!sameAccountPreferenceValue(persisted[field] as UnparsedWireValue, value)) {
-          changed.push(field);
+  ): Effect.Effect<
+    SettingsUpdateResult & { changed: readonly AccountPreferenceField[] },
+    PlatformError
+  > {
+    return Effect.gen(this, function* () {
+      const changed: AccountPreferenceField[] = [];
+      yield* this.#mutate((persisted) => {
+        if (expected && persisted.account?.email !== expected.accountEmail) return undefined;
+        const nextSettings = expected
+          ? accountPreferencesWithLocalChanges(
+              settings,
+              accountPreferencesFromPersisted(persisted),
+              expected.preferences,
+            )
+          : settings;
+        const next: PersistedSettings = { ...persisted };
+        for (const field of ACCOUNT_PREFERENCE_FIELDS) {
+          // SAFETY: AccountPreferences is the parsed subset of JSON-compatible stored app settings.
+          const value = nextSettings[field] as UnparsedWireValue;
+          // SAFETY: AccountPreferenceField selects the same persisted JSON-compatible setting value.
+          if (!sameAccountPreferenceValue(persisted[field] as UnparsedWireValue, value)) {
+            changed.push(field);
+          }
+          if (value === undefined) delete next[field];
+          else Object.assign(next, { [field]: value });
         }
-        if (value === undefined) delete next[field];
-        else Object.assign(next, { [field]: value });
-      }
-      return changed.length > 0 ? next : undefined;
+        return changed.length > 0 ? next : undefined;
+      });
+      return {
+        status: ACTION_RESULT_STATUS.ACCEPTED,
+        settings: yield* this.snapshot(),
+        changed,
+      };
     });
-    return {
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      settings: await this.snapshot(),
-      changed,
-    };
   }
 
-  async accountPreferencesSyncBaseline(
+  accountPreferencesSyncBaseline(
     accountEmail: string,
-  ): Promise<AccountPreferences | undefined> {
-    const sync = (await this.#load()).accountPreferencesSync;
-    return sync?.accountEmail === accountEmail ? sync.preferences : undefined;
+  ): Effect.Effect<AccountPreferences | undefined, PlatformError> {
+    return Effect.map(this.#load(), ({ accountPreferencesSync: sync }) =>
+      sync?.accountEmail === accountEmail ? sync.preferences : undefined,
+    );
   }
 
-  async setAccountPreferencesSyncBaseline(
+  setAccountPreferencesSyncBaseline(
     accountEmail: string,
     preferences: AccountPreferences,
-  ): Promise<boolean> {
-    let saved = false;
-    await this.#mutate((persisted) => {
-      if (persisted.account?.email !== accountEmail) return undefined;
-      saved = true;
-      if (
-        persisted.accountPreferencesSync?.accountEmail === accountEmail &&
-        JSON.stringify(persisted.accountPreferencesSync.preferences) === JSON.stringify(preferences)
-      ) {
-        return undefined;
-      }
-      return { ...persisted, accountPreferencesSync: { accountEmail, preferences } };
+  ): Effect.Effect<boolean, PlatformError> {
+    return Effect.gen(this, function* () {
+      let saved = false;
+      yield* this.#mutate((persisted) => {
+        if (persisted.account?.email !== accountEmail) return undefined;
+        saved = true;
+        if (
+          persisted.accountPreferencesSync?.accountEmail === accountEmail &&
+          JSON.stringify(persisted.accountPreferencesSync.preferences) ===
+            JSON.stringify(preferences)
+        ) {
+          return undefined;
+        }
+        return { ...persisted, accountPreferencesSync: { accountEmail, preferences } };
+      });
+      return saved;
     });
-    return saved;
   }
 
   /** Clears one map entry only if it still holds the value the caller read. */
-  async clearEntryIfUnchanged<Field extends KeyedAppSettingField>(
+  clearEntryIfUnchanged<Field extends KeyedAppSettingField>(
     field: Field,
     key: string,
     expected: SettingEntryValue<Field>,
-  ): Promise<SettingsUpdateResult & { cleared: boolean }> {
+  ): Effect.Effect<SettingsUpdateResult & { cleared: boolean }, PlatformError> {
     // SAFETY: a setting entry's own value is one of the wire values it was parsed from.
     const held = expected as UnparsedWireValue;
-    const cleared = await this.#mutate((persisted) => {
-      // SAFETY: KeyedAppSettingField identifies fields whose stored value is a wire record.
-      const current = persisted[field] as WireRecord | undefined;
-      if (!sameSettingEntry(field, current?.[key], held)) return undefined;
-      const entries = { ...current };
-      delete entries[key];
-      const next: PersistedSettings = { ...persisted };
-      if (Object.keys(entries).length > 0) Object.assign(next, { [field]: entries });
-      else delete next[field];
-      return next;
+    return Effect.gen(this, function* () {
+      const cleared = yield* this.#mutate((persisted) => {
+        // SAFETY: KeyedAppSettingField identifies fields whose stored value is a wire record.
+        const current = persisted[field] as WireRecord | undefined;
+        if (!sameSettingEntry(field, current?.[key], held)) return undefined;
+        const entries = { ...current };
+        delete entries[key];
+        const next: PersistedSettings = { ...persisted };
+        if (Object.keys(entries).length > 0) Object.assign(next, { [field]: entries });
+        else delete next[field];
+        return next;
+      });
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: yield* this.snapshot(), cleared };
     });
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: await this.snapshot(), cleared };
   }
   #secretStorage: SecretStorage = SECRET_STORAGE.UNKNOWN;
 
@@ -652,156 +672,168 @@ export class SettingsStore {
     this.#cipher = options.cipher;
     this.#overrides = options.overrides;
     this.#credentialsUsable = options.credentialsUsable ?? true;
-    this.#runtime = options.runtime;
+    this.#fileSystem = options.fileSystem;
   }
 
-  async snapshot(): Promise<AppSettings> {
-    const persisted = await this.#load();
-    const voiceCapability = await this.#voiceCapability(persisted);
-    const sources = await Promise.all(
-      CREDENTIAL_PROVIDER_LIST.map(
-        async (provider) => [provider.id, (await this.#resolveApiKey(provider)).source] as const,
-      ),
-    );
-    return {
-      stored: {
-        ...storedSettingsFromPersisted(persisted),
-        // Resolved the way the session source resolves it, so the panel marks
-        // what would actually be heard while the persisted file remains optional.
-        voice: persisted.voice ?? this.#overrides.voice ?? LIVE_DEFAULTS.VOICE,
-        voiceSource: voiceCapability.source,
-        formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
-      },
-      status: {
-        // SAFETY: the registry list contains every credential provider exactly once.
-        credentialSources: Object.fromEntries(sources) as Record<
-          CredentialProviderId,
-          CredentialSource
-        >,
-        // Reports what storing a key has already established, and asks nothing on
-        // its own: a snapshot is taken on every launch, and most of them are for
-        // a user with no key to protect.
-        secretStorage: this.#secretStorage,
-        // Whether a spoken turn could actually be minted: a key resolved, and this
-        // run will use it. Resolved here rather than left to the panel because it
-        // is the same question the voice and the pace are answered by — what would
-        // actually happen — and it travels with every settings reply, so storing a
-        // key is what turns voice on and deleting one is what turns it off.
-        voiceAvailable: voiceCapability.available,
-        // Whether this build can offer the Google Calendar sign-in at all: a
-        // registered OAuth client resolved, and this run would use what it
-        // grants. Without one the integration is not drawn at all.
-        calendarSignInAvailable:
-          this.#credentialsUsable && this.#overrides.googleCalendarSignIn !== undefined,
-        // Whether this build can offer the Apple Calendar connection: a Mac to
-        // read, and a run that would use what macOS grants. No client gates it
-        // the way the sign-ins are gated — the grant lives with the system.
-        appleCalendarAvailable: this.#credentialsUsable && process.platform === "darwin",
-        // The accounts without their grants: which are connected and which
-        // calendars count is the renderer's to draw; the tokens never travel.
-        calendarAccounts: (persisted.calendarAccounts ?? []).map((account) => ({
-          id: account.id,
-          selectedCalendarIds: account.calendars,
-        })),
-        // The Apple Calendar connection on the same terms: the fact and the
-        // chosen calendars, with nothing behind them to keep from travelling.
-        ...(persisted.appleCalendar
-          ? {
-              appleCalendar: {
-                id: APPLE_CALENDAR_ID,
-                selectedCalendarIds: persisted.appleCalendar.calendars,
-              },
-            }
-          : undefined),
-      },
-    };
-  }
-
-  /** Returns account credentials only to the main process. */
-  async readAccount(): Promise<StoredAccount | undefined> {
-    const account = (await this.#load()).account;
-    if (!account) return undefined;
-    return this.#decryptRecord(account.tokenCipher, (tokens) => {
-      const { accessToken, refreshToken } = tokens;
-      if (!isWireString(accessToken) || !isWireString(refreshToken)) return undefined;
+  snapshot(): Effect.Effect<AppSettings, PlatformError> {
+    return Effect.gen(this, function* () {
+      const persisted = yield* this.#load();
+      const voiceCapability = yield* this.#voiceCapability(persisted);
+      const sources = yield* Effect.forEach(CREDENTIAL_PROVIDER_LIST, (provider) =>
+        Effect.map(
+          this.#resolveApiKey(provider),
+          (resolved) => [provider.id, resolved.source] as const,
+        ),
+      );
       return {
-        accessToken,
-        refreshToken,
-        ...(account.id ? { id: account.id } : undefined),
-        email: account.email,
-        ...(account.name ? { name: account.name } : undefined),
-        ...(account.pictureUrl ? { pictureUrl: account.pictureUrl } : undefined),
-        provider: account.provider,
+        stored: {
+          ...storedSettingsFromPersisted(persisted),
+          // Resolved the way the session source resolves it, so the panel marks
+          // what would actually be heard while the persisted file remains optional.
+          voice: persisted.voice ?? this.#overrides.voice ?? LIVE_DEFAULTS.VOICE,
+          voiceSource: voiceCapability.source,
+          formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
+        },
+        status: {
+          // SAFETY: the registry list contains every credential provider exactly once.
+          credentialSources: Object.fromEntries(sources) as Record<
+            CredentialProviderId,
+            CredentialSource
+          >,
+          // Reports what storing a key has already established, and asks nothing on
+          // its own: a snapshot is taken on every launch, and most of them are for
+          // a user with no key to protect.
+          secretStorage: this.#secretStorage,
+          // Whether a spoken turn could actually be minted: a key resolved, and this
+          // run will use it. Resolved here rather than left to the panel because it
+          // is the same question the voice and the pace are answered by — what would
+          // actually happen — and it travels with every settings reply, so storing a
+          // key is what turns voice on and deleting one is what turns it off.
+          voiceAvailable: voiceCapability.available,
+          // Whether this build can offer the Google Calendar sign-in at all: a
+          // registered OAuth client resolved, and this run would use what it
+          // grants. Without one the integration is not drawn at all.
+          calendarSignInAvailable:
+            this.#credentialsUsable && this.#overrides.googleCalendarSignIn !== undefined,
+          // Whether this build can offer the Apple Calendar connection: a Mac to
+          // read, and a run that would use what macOS grants. No client gates it
+          // the way the sign-ins are gated — the grant lives with the system.
+          appleCalendarAvailable: this.#credentialsUsable && process.platform === "darwin",
+          // The accounts without their grants: which are connected and which
+          // calendars count is the renderer's to draw; the tokens never travel.
+          calendarAccounts: (persisted.calendarAccounts ?? []).map((account) => ({
+            id: account.id,
+            selectedCalendarIds: account.calendars,
+          })),
+          // The Apple Calendar connection on the same terms: the fact and the
+          // chosen calendars, with nothing behind them to keep from travelling.
+          ...(persisted.appleCalendar
+            ? {
+                appleCalendar: {
+                  id: APPLE_CALENDAR_ID,
+                  selectedCalendarIds: persisted.appleCalendar.calendars,
+                },
+              }
+            : undefined),
+        },
       };
     });
   }
 
-  async accountSnapshot(): Promise<AccountSnapshot> {
-    const account = await this.readAccount();
-    return account
-      ? {
-          status: ACCOUNT_STATUS.SIGNED_IN,
-          email: account.email,
-          ...(account.name ? { name: account.name } : undefined),
-          ...(account.pictureUrl ? { pictureUrl: account.pictureUrl } : undefined),
-          provider: account.provider,
-        }
-      : { status: ACCOUNT_STATUS.SIGNED_OUT };
-  }
-
-  /** Stores both OAuth tokens under one Keychain-backed ciphertext. */
-  async setAccount(account: StoredAccount): Promise<AccountSnapshot> {
-    if (!this.#secretStorageUsable()) {
-      throw new Error("Encrypted credential storage is unavailable on this system.");
-    }
-    await this.#mutate((persisted) => {
-      const tokenCipher = this.#cipher
-        .encrypt(
-          JSON.stringify({
-            accessToken: account.accessToken,
-            refreshToken: account.refreshToken,
-          }),
-        )
-        .toString("base64");
-      const next: PersistedSettings = {
-        ...persisted,
-        account: {
-          tokenCipher,
+  /** Returns account credentials only to the main process. */
+  readAccount(): Effect.Effect<StoredAccount | undefined, PlatformError> {
+    return Effect.map(this.#load(), ({ account }) => {
+      if (!account) return undefined;
+      return this.#decryptRecord(account.tokenCipher, (tokens) => {
+        const { accessToken, refreshToken } = tokens;
+        if (!isWireString(accessToken) || !isWireString(refreshToken)) return undefined;
+        return {
+          accessToken,
+          refreshToken,
           ...(account.id ? { id: account.id } : undefined),
           email: account.email,
           ...(account.name ? { name: account.name } : undefined),
           ...(account.pictureUrl ? { pictureUrl: account.pictureUrl } : undefined),
           provider: account.provider,
-        },
-      };
-      if (persisted.account?.email && persisted.account.email !== account.email) {
+        };
+      });
+    });
+  }
+
+  accountSnapshot(): Effect.Effect<AccountSnapshot, PlatformError> {
+    return Effect.map(this.readAccount(), (account) =>
+      account
+        ? {
+            status: ACCOUNT_STATUS.SIGNED_IN,
+            email: account.email,
+            ...(account.name ? { name: account.name } : undefined),
+            ...(account.pictureUrl ? { pictureUrl: account.pictureUrl } : undefined),
+            provider: account.provider,
+          }
+        : { status: ACCOUNT_STATUS.SIGNED_OUT },
+    );
+  }
+
+  /** Stores both OAuth tokens under one Keychain-backed ciphertext. */
+  setAccount(account: StoredAccount): Effect.Effect<AccountSnapshot, PlatformError> {
+    return Effect.gen(this, function* () {
+      if (!this.#secretStorageUsable()) {
+        throw new Error("Encrypted credential storage is unavailable on this system.");
+      }
+      yield* this.#mutate((persisted) => {
+        const tokenCipher = this.#cipher
+          .encrypt(
+            JSON.stringify({
+              accessToken: account.accessToken,
+              refreshToken: account.refreshToken,
+            }),
+          )
+          .toString("base64");
+        const next: PersistedSettings = {
+          ...persisted,
+          account: {
+            tokenCipher,
+            ...(account.id ? { id: account.id } : undefined),
+            email: account.email,
+            ...(account.name ? { name: account.name } : undefined),
+            ...(account.pictureUrl ? { pictureUrl: account.pictureUrl } : undefined),
+            provider: account.provider,
+          },
+        };
+        if (persisted.account?.email && persisted.account.email !== account.email) {
+          for (const field of ACCOUNT_PREFERENCE_FIELDS) {
+            delete next[field];
+          }
+          delete next.accountPreferencesSync;
+        }
+        return next;
+      });
+      return yield* this.accountSnapshot();
+    });
+  }
+
+  clearAccount(): Effect.Effect<AccountSnapshot, PlatformError> {
+    return Effect.as(
+      this.#mutate((persisted) => {
+        if (!persisted.account) return undefined;
+        const { account: _account, ...withoutAccount } = persisted;
+        const next: PersistedSettings = { ...withoutAccount };
         for (const field of ACCOUNT_PREFERENCE_FIELDS) {
           delete next[field];
         }
         delete next.accountPreferencesSync;
-      }
-      return next;
-    });
-    return this.accountSnapshot();
-  }
-
-  async clearAccount(): Promise<AccountSnapshot> {
-    await this.#mutate((persisted) => {
-      if (!persisted.account) return undefined;
-      const { account: _account, ...withoutAccount } = persisted;
-      const next: PersistedSettings = { ...withoutAccount };
-      for (const field of ACCOUNT_PREFERENCE_FIELDS) {
-        delete next[field];
-      }
-      delete next.accountPreferencesSync;
-      return next;
-    });
-    return { status: ACCOUNT_STATUS.SIGNED_OUT };
+        return next;
+      }),
+      { status: ACCOUNT_STATUS.SIGNED_OUT },
+    );
   }
 
   /** Main-process only: the source the minter and the reviewer are built for. */
-  async readVoiceSource(): Promise<VoiceSource> {
-    return (await this.#voiceCapability(await this.#load())).source;
+  readVoiceSource(): Effect.Effect<VoiceSource, PlatformError> {
+    return Effect.map(
+      Effect.flatMap(this.#load(), (persisted) => this.#voiceCapability(persisted)),
+      (capability) => capability.source,
+    );
   }
 
   /**
@@ -809,14 +841,16 @@ export class SettingsStore {
    * what this run holds. One resolution, so the panel's snapshot and the
    * minter's own read can never answer the question differently.
    */
-  async #voiceCapability(persisted: PersistedSettings) {
-    return resolveVoiceCapability({
-      credentialsUsable: this.#credentialsUsable,
-      keyConfigured:
-        this.#credentialsUsable &&
-        (await this.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)) !== undefined,
-      accountSignedIn: this.#credentialsUsable && (await this.readAccount()) !== undefined,
-      chosenSource: persisted.voiceSource,
+  #voiceCapability(persisted: PersistedSettings) {
+    return Effect.gen(this, function* () {
+      const key = yield* this.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID);
+      const account = yield* this.readAccount();
+      return resolveVoiceCapability({
+        credentialsUsable: this.#credentialsUsable,
+        keyConfigured: this.#credentialsUsable && key !== undefined,
+        accountSignedIn: this.#credentialsUsable && account !== undefined,
+        chosenSource: persisted.voiceSource,
+      });
     });
   }
 
@@ -825,10 +859,10 @@ export class SettingsStore {
    * reads. A provider with no key resolves to nothing, so its adapter observes
    * nothing and issues no request.
    */
-  async readApiKey(providerId: CredentialProviderId): Promise<string | undefined> {
+  readApiKey(providerId: CredentialProviderId): Effect.Effect<string | undefined, PlatformError> {
     const provider = CREDENTIAL_PROVIDER_LIST.find((candidate) => candidate.id === providerId);
-    if (!provider) return undefined;
-    return (await this.#resolveApiKey(provider)).apiKey;
+    if (!provider) return Effect.succeed(undefined);
+    return Effect.map(this.#resolveApiKey(provider), (resolved) => resolved.apiKey);
   }
 
   /**
@@ -837,23 +871,28 @@ export class SettingsStore {
    * an environment key was configured for this machine's shell, not entered
    * into Luke, so it is not Luke's to send anywhere.
    */
-  async readStoredApiKey(providerId: CredentialProviderId): Promise<string | undefined> {
+  readStoredApiKey(
+    providerId: CredentialProviderId,
+  ): Effect.Effect<string | undefined, PlatformError> {
     const provider = CREDENTIAL_PROVIDER_LIST.find((candidate) => candidate.id === providerId);
-    if (!provider) return undefined;
-    const resolved = await this.#resolveApiKey(provider);
-    return resolved.source === CREDENTIAL_SOURCE.ENCRYPTED_FILE ? resolved.apiKey : undefined;
+    if (!provider) return Effect.succeed(undefined);
+    return Effect.map(this.#resolveApiKey(provider), (resolved) =>
+      resolved.source === CREDENTIAL_SOURCE.ENCRYPTED_FILE ? resolved.apiKey : undefined,
+    );
   }
 
   /** Which account this Mac's provider keys were last synced for; see the field. */
-  async readVaultSyncAccount(): Promise<string | undefined> {
-    return (await this.#load()).vaultSyncAccount;
+  readVaultSyncAccount(): Effect.Effect<string | undefined, PlatformError> {
+    return Effect.map(this.#load(), (persisted) => persisted.vaultSyncAccount);
   }
 
-  async setVaultSyncAccount(accountKey: string): Promise<void> {
-    await this.#mutate((persisted) =>
-      persisted.vaultSyncAccount === accountKey
-        ? undefined
-        : { ...persisted, vaultSyncAccount: accountKey },
+  setVaultSyncAccount(accountKey: string): Effect.Effect<void, PlatformError> {
+    return Effect.asVoid(
+      this.#mutate((persisted) =>
+        persisted.vaultSyncAccount === accountKey
+          ? undefined
+          : { ...persisted, vaultSyncAccount: accountKey },
+      ),
     );
   }
 
@@ -862,58 +901,60 @@ export class SettingsStore {
    * key the user cannot use comes back as a `reason` rather than an exception,
    * so only an unexpected filesystem failure throws.
    */
-  async setApiKey(
+  setApiKey(
     providerId: CredentialProviderId,
     apiKey: string | undefined,
-  ): Promise<SettingsUpdateResult> {
-    const keyFormat = CREDENTIAL_PROVIDER_LIST.find(
-      (candidate) => candidate.id === providerId,
-    )?.keyFormat;
-    const normalized = apiKey?.trim();
-    // Clearing a key needs no cipher, so only a key on its way in asks whether
-    // there is anywhere to put it.
-    const rejection = normalized
-      ? !this.#secretStorageUsable()
-        ? "Encrypted credential storage is unavailable on this system."
-        : apiKeyRejection(normalized, keyFormat)
-      : undefined;
-    if (rejection)
-      return {
-        status: ACTION_RESULT_STATUS.REJECTED,
-        settings: await this.snapshot(),
-        reason: rejection,
-      };
+  ): Effect.Effect<SettingsUpdateResult, PlatformError> {
+    return Effect.gen(this, function* () {
+      const keyFormat = CREDENTIAL_PROVIDER_LIST.find(
+        (candidate) => candidate.id === providerId,
+      )?.keyFormat;
+      const normalized = apiKey?.trim();
+      // Clearing a key needs no cipher, so only a key on its way in asks whether
+      // there is anywhere to put it.
+      const rejection = normalized
+        ? !this.#secretStorageUsable()
+          ? "Encrypted credential storage is unavailable on this system."
+          : apiKeyRejection(normalized, keyFormat)
+        : undefined;
+      if (rejection)
+        return {
+          status: ACTION_RESULT_STATUS.REJECTED,
+          settings: yield* this.snapshot(),
+          reason: rejection,
+        };
 
-    await this.#mutate(
-      (persisted) => {
-        const ciphertext = normalized
-          ? this.#cipher.encrypt(normalized).toString("base64")
-          : undefined;
-        // Connecting the key voice runs on is choosing it: someone who parked on
-        // the free allowance and later pastes a key means to use that key, and a
-        // stored preference quietly ignoring it would look like the key failed
-        // to save. Deleting one leaves the choice alone — there is nothing left
-        // for it to hold back, and it says where to land if another key arrives.
-        const chooses =
-          providerId === VOICE_CREDENTIAL_PROVIDER_ID &&
-          ciphertext !== undefined &&
-          persisted.voiceSource !== VOICE_SOURCE.KEY;
-        // A key that is already stored is not a write — unless it is also the
-        // act of choosing it, which pasting the same key back while parked on
-        // the allowance is.
-        if (persisted.apiKeys[providerId] === ciphertext && !chooses) return undefined;
-        // Every other provider's ciphertext is carried over, so saving one key
-        // never disturbs another.
-        const apiKeys = { ...persisted.apiKeys };
-        if (ciphertext) apiKeys[providerId] = ciphertext;
-        else delete apiKeys[providerId];
-        const next: PersistedSettings = { ...persisted, apiKeys };
-        if (chooses) next.voiceSource = VOICE_SOURCE.KEY;
-        return next;
-      },
-      () => this.#resolved.delete(providerId),
-    );
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
+      yield* this.#mutate(
+        (persisted) => {
+          const ciphertext = normalized
+            ? this.#cipher.encrypt(normalized).toString("base64")
+            : undefined;
+          // Connecting the key voice runs on is choosing it: someone who parked on
+          // the free allowance and later pastes a key means to use that key, and a
+          // stored preference quietly ignoring it would look like the key failed
+          // to save. Deleting one leaves the choice alone — there is nothing left
+          // for it to hold back, and it says where to land if another key arrives.
+          const chooses =
+            providerId === VOICE_CREDENTIAL_PROVIDER_ID &&
+            ciphertext !== undefined &&
+            persisted.voiceSource !== VOICE_SOURCE.KEY;
+          // A key that is already stored is not a write — unless it is also the
+          // act of choosing it, which pasting the same key back while parked on
+          // the allowance is.
+          if (persisted.apiKeys[providerId] === ciphertext && !chooses) return undefined;
+          // Every other provider's ciphertext is carried over, so saving one key
+          // never disturbs another.
+          const apiKeys = { ...persisted.apiKeys };
+          if (ciphertext) apiKeys[providerId] = ciphertext;
+          else delete apiKeys[providerId];
+          const next: PersistedSettings = { ...persisted, apiKeys };
+          if (chooses) next.voiceSource = VOICE_SOURCE.KEY;
+          return next;
+        },
+        () => this.#resolved.delete(providerId),
+      );
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: yield* this.snapshot() };
+    });
   }
 
   /**
@@ -923,68 +964,72 @@ export class SettingsStore {
    * choices — the choices are the user's, and a fresh grant is not a fresh
    * mind about them.
    */
-  async addCalendarAccount(
+  addCalendarAccount(
     accountId: string,
     refreshToken: string,
     selectedCalendarIds: readonly string[],
-  ): Promise<SettingsUpdateResult> {
-    const id = calendarIdentifierText(accountId);
-    const normalized = refreshToken.trim();
-    const rejection = !id
-      ? "Google answered the sign-in without naming an account."
-      : !this.#secretStorageUsable()
-        ? "Encrypted credential storage is unavailable on this system."
-        : // The shape rules a pasted key answers to: a grant is Google's to
-          // shape, and only sendability is checked.
-          apiKeyRejection(normalized);
-    if (rejection || !id) {
-      return {
-        status: ACTION_RESULT_STATUS.REJECTED,
-        settings: await this.snapshot(),
-        reason: rejection ?? "Google answered the sign-in without naming an account.",
-      };
-    }
-
-    await this.#mutate(
-      (persisted) => {
-        const token = this.#cipher.encrypt(normalized).toString("base64");
-        const existing = persisted.calendarAccounts ?? [];
-        const held = existing.find((account) => account.id === id);
-        if (!held && existing.length >= MAXIMUM_CALENDAR_ACCOUNTS) {
-          throw new Error("More calendar accounts than the store keeps");
-        }
-        const account: PersistedCalendarAccount = {
-          id,
-          token,
-          calendars: held
-            ? held.calendars
-            : sanitizedCalendarIds(unparsedWire(selectedCalendarIds)),
+  ): Effect.Effect<SettingsUpdateResult, PlatformError> {
+    return Effect.gen(this, function* () {
+      const id = calendarIdentifierText(accountId);
+      const normalized = refreshToken.trim();
+      const rejection = !id
+        ? "Google answered the sign-in without naming an account."
+        : !this.#secretStorageUsable()
+          ? "Encrypted credential storage is unavailable on this system."
+          : // The shape rules a pasted key answers to: a grant is Google's to
+            // shape, and only sendability is checked.
+            apiKeyRejection(normalized);
+      if (rejection || !id) {
+        return {
+          status: ACTION_RESULT_STATUS.REJECTED,
+          settings: yield* this.snapshot(),
+          reason: rejection ?? "Google answered the sign-in without naming an account.",
         };
-        return withCalendarAccounts(
-          persisted,
-          held
-            ? existing.map((candidate) => (candidate.id === id ? account : candidate))
-            : [...existing, account],
-        );
-      },
-      () => this.#forgetCalendarAccounts(),
-    );
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
+      }
+
+      yield* this.#mutate(
+        (persisted) => {
+          const token = this.#cipher.encrypt(normalized).toString("base64");
+          const existing = persisted.calendarAccounts ?? [];
+          const held = existing.find((account) => account.id === id);
+          if (!held && existing.length >= MAXIMUM_CALENDAR_ACCOUNTS) {
+            throw new Error("More calendar accounts than the store keeps");
+          }
+          const account: PersistedCalendarAccount = {
+            id,
+            token,
+            calendars: held
+              ? held.calendars
+              : sanitizedCalendarIds(unparsedWire(selectedCalendarIds)),
+          };
+          return withCalendarAccounts(
+            persisted,
+            held
+              ? existing.map((candidate) => (candidate.id === id ? account : candidate))
+              : [...existing, account],
+          );
+        },
+        () => this.#forgetCalendarAccounts(),
+      );
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: yield* this.snapshot() };
+    });
   }
 
   /** Disconnects one account, deleting its stored grant with it. */
-  async removeCalendarAccount(accountId: string): Promise<SettingsUpdateResult> {
-    await this.#mutate(
-      (persisted) => {
-        const existing = persisted.calendarAccounts ?? [];
-        const calendarAccounts = existing.filter((account) => account.id !== accountId);
-        return calendarAccounts.length === existing.length
-          ? undefined
-          : withCalendarAccounts(persisted, calendarAccounts);
-      },
-      () => this.#forgetCalendarAccounts(),
-    );
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
+  removeCalendarAccount(accountId: string): Effect.Effect<SettingsUpdateResult, PlatformError> {
+    return Effect.gen(this, function* () {
+      yield* this.#mutate(
+        (persisted) => {
+          const existing = persisted.calendarAccounts ?? [];
+          const calendarAccounts = existing.filter((account) => account.id !== accountId);
+          return calendarAccounts.length === existing.length
+            ? undefined
+            : withCalendarAccounts(persisted, calendarAccounts);
+        },
+        () => this.#forgetCalendarAccounts(),
+      );
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: yield* this.snapshot() };
+    });
   }
 
   /**
@@ -995,54 +1040,56 @@ export class SettingsStore {
    * process validates a selection against its latest observation — so only
    * the value's shape is held here.
    */
-  async setCalendarSelected(
+  setCalendarSelected(
     accountId: string,
     calendarId: string,
     selected: boolean,
-  ): Promise<SettingsUpdateResult> {
-    const id = calendarIdentifierText(calendarId);
-    if (!id)
-      return {
-        status: ACTION_RESULT_STATUS.REJECTED,
-        settings: await this.snapshot(),
-        reason: "That is not a calendar id.",
-      };
-    let missing: string | undefined;
-    const apple = accountId === APPLE_CALENDAR_ID;
-    await this.#mutate(
-      (persisted) => {
-        if (apple) {
-          const held = persisted.appleCalendar;
+  ): Effect.Effect<SettingsUpdateResult, PlatformError> {
+    return Effect.gen(this, function* () {
+      const id = calendarIdentifierText(calendarId);
+      if (!id)
+        return {
+          status: ACTION_RESULT_STATUS.REJECTED,
+          settings: yield* this.snapshot(),
+          reason: "That is not a calendar id.",
+        };
+      let missing: string | undefined;
+      const apple = accountId === APPLE_CALENDAR_ID;
+      yield* this.#mutate(
+        (persisted) => {
+          if (apple) {
+            const held = persisted.appleCalendar;
+            if (!held) {
+              missing = "Apple Calendar is not connected.";
+              return undefined;
+            }
+            const calendars = toggledCalendarSelection(held.calendars, id, selected);
+            return calendars ? withAppleCalendar(persisted, { calendars }) : undefined;
+          }
+          const existing = persisted.calendarAccounts ?? [];
+          const held = existing.find((account) => account.id === accountId);
           if (!held) {
-            missing = "Apple Calendar is not connected.";
+            missing = "That calendar account is not connected.";
             return undefined;
           }
           const calendars = toggledCalendarSelection(held.calendars, id, selected);
-          return calendars ? withAppleCalendar(persisted, { calendars }) : undefined;
-        }
-        const existing = persisted.calendarAccounts ?? [];
-        const held = existing.find((account) => account.id === accountId);
-        if (!held) {
-          missing = "That calendar account is not connected.";
-          return undefined;
-        }
-        const calendars = toggledCalendarSelection(held.calendars, id, selected);
-        if (!calendars) return undefined;
-        return withCalendarAccounts(
-          persisted,
-          existing.map((account) =>
-            account.id === accountId ? { ...account, calendars } : account,
-          ),
-        );
-      },
-      // Only a Google account's grant is decrypted, so only its edit costs the
-      // cache; this Mac's connection carries no grant to have cached.
-      apple ? undefined : () => this.#forgetCalendarAccounts(),
-    );
-    const settings = await this.snapshot();
-    return missing
-      ? { status: ACTION_RESULT_STATUS.REJECTED, settings, reason: missing }
-      : { status: ACTION_RESULT_STATUS.ACCEPTED, settings };
+          if (!calendars) return undefined;
+          return withCalendarAccounts(
+            persisted,
+            existing.map((account) =>
+              account.id === accountId ? { ...account, calendars } : account,
+            ),
+          );
+        },
+        // Only a Google account's grant is decrypted, so only its edit costs the
+        // cache; this Mac's connection carries no grant to have cached.
+        apple ? undefined : () => this.#forgetCalendarAccounts(),
+      );
+      const settings = yield* this.snapshot();
+      return missing
+        ? { status: ACTION_RESULT_STATUS.REJECTED, settings, reason: missing }
+        : { status: ACTION_RESULT_STATUS.ACCEPTED, settings };
+    });
   }
 
   /**
@@ -1051,17 +1098,19 @@ export class SettingsStore {
    * another OS account, a rotated Keychain — is skipped; its row still shows
    * connected, and the failing read is what says to sign in again.
    */
-  async readCalendarAccounts(): Promise<readonly CalendarAccountCredential[]> {
-    if (this.#resolvedCalendarAccounts) return this.#resolvedCalendarAccounts;
-    const persisted = await this.#load();
-    const accounts: CalendarAccountCredential[] = [];
-    for (const account of persisted.calendarAccounts ?? []) {
-      const refreshToken = this.#decryptSecret(account.token);
-      if (!refreshToken) continue;
-      accounts.push({ id: account.id, refreshToken, selectedCalendarIds: account.calendars });
-    }
-    this.#resolvedCalendarAccounts = accounts;
-    return accounts;
+  readCalendarAccounts(): Effect.Effect<readonly CalendarAccountCredential[], PlatformError> {
+    return Effect.gen(this, function* () {
+      if (this.#resolvedCalendarAccounts) return this.#resolvedCalendarAccounts;
+      const persisted = yield* this.#load();
+      const accounts: CalendarAccountCredential[] = [];
+      for (const account of persisted.calendarAccounts ?? []) {
+        const refreshToken = this.#decryptSecret(account.token);
+        if (!refreshToken) continue;
+        accounts.push({ id: account.id, refreshToken, selectedCalendarIds: account.calendars });
+      }
+      this.#resolvedCalendarAccounts = accounts;
+      return accounts;
+    });
   }
 
   /**
@@ -1071,28 +1120,32 @@ export class SettingsStore {
    * choices: the choices are the user's, and asking again is not a fresh
    * mind about them.
    */
-  async connectAppleCalendar(
+  connectAppleCalendar(
     selectedCalendarIds: readonly string[],
-  ): Promise<SettingsUpdateResult> {
-    await this.#mutate((persisted) =>
-      persisted.appleCalendar
-        ? undefined
-        : withAppleCalendar(persisted, {
-            calendars: sanitizedCalendarIds(unparsedWire(selectedCalendarIds)),
-          }),
-    );
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
+  ): Effect.Effect<SettingsUpdateResult, PlatformError> {
+    return Effect.gen(this, function* () {
+      yield* this.#mutate((persisted) =>
+        persisted.appleCalendar
+          ? undefined
+          : withAppleCalendar(persisted, {
+              calendars: sanitizedCalendarIds(unparsedWire(selectedCalendarIds)),
+            }),
+      );
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: yield* this.snapshot() };
+    });
   }
 
   /**
    * Disconnects this Mac's Calendar. Only the connection is Luke's to delete:
    * the system grant stays macOS's, withdrawable in System Settings.
    */
-  async disconnectAppleCalendar(): Promise<SettingsUpdateResult> {
-    await this.#mutate((persisted) =>
-      persisted.appleCalendar ? withAppleCalendar(persisted, undefined) : undefined,
-    );
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
+  disconnectAppleCalendar(): Effect.Effect<SettingsUpdateResult, PlatformError> {
+    return Effect.gen(this, function* () {
+      yield* this.#mutate((persisted) =>
+        persisted.appleCalendar ? withAppleCalendar(persisted, undefined) : undefined,
+      );
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: yield* this.snapshot() };
+    });
   }
 
   /** The decrypted account list a written one makes stale. */
@@ -1105,15 +1158,19 @@ export class SettingsStore {
    * no grant decrypted and no keychain touched, for the onboarding reconcile
    * that only needs to know the step's purpose is already standing.
    */
-  async calendarConnectionStored(): Promise<boolean> {
-    const persisted = await this.#load();
-    return (persisted.calendarAccounts ?? []).length > 0 || persisted.appleCalendar !== undefined;
+  calendarConnectionStored(): Effect.Effect<boolean, PlatformError> {
+    return Effect.map(
+      this.#load(),
+      (persisted) =>
+        (persisted.calendarAccounts ?? []).length > 0 || persisted.appleCalendar !== undefined,
+    );
   }
 
   /** The connection as the reader is fed it; absent means never run the helper. */
-  async readAppleCalendarConnection(): Promise<AppleCalendarConnection | undefined> {
-    const held = (await this.#load()).appleCalendar;
-    return held ? { selectedCalendarIds: held.calendars } : undefined;
+  readAppleCalendarConnection(): Effect.Effect<AppleCalendarConnection | undefined, PlatformError> {
+    return Effect.map(this.#load(), ({ appleCalendar: held }) =>
+      held ? { selectedCalendarIds: held.calendars } : undefined,
+    );
   }
 
   /**
@@ -1127,19 +1184,21 @@ export class SettingsStore {
    * A scope already at its defaults writes nothing, like any other setter
    * asked for the value it holds.
    */
-  async resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult> {
-    await this.#mutate((persisted) => {
-      const next: PersistedSettings = { ...persisted };
-      for (const field of APP_SETTING_FIELDS) {
-        const definition = APP_SETTING_SCHEMA[field];
-        if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
-        if (definition.guard(undefined).valid) delete next[field];
-        else Object.assign(next, { [field]: definition.default });
-      }
-      const changed = APP_SETTING_FIELDS.some((field) => next[field] !== persisted[field]);
-      return changed ? next : undefined;
+  resetSettings(scope: SettingsResetScope): Effect.Effect<SettingsUpdateResult, PlatformError> {
+    return Effect.gen(this, function* () {
+      yield* this.#mutate((persisted) => {
+        const next: PersistedSettings = { ...persisted };
+        for (const field of APP_SETTING_FIELDS) {
+          const definition = APP_SETTING_SCHEMA[field];
+          if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
+          if (definition.guard(undefined).valid) delete next[field];
+          else Object.assign(next, { [field]: definition.default });
+        }
+        const changed = APP_SETTING_FIELDS.some((field) => next[field] !== persisted[field]);
+        return changed ? next : undefined;
+      });
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: yield* this.snapshot() };
     });
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
   /**
@@ -1153,39 +1212,22 @@ export class SettingsStore {
    * disturb would cost a Keychain read for nothing. Answers whether a write
    * landed.
    */
-  async #mutate(
+  #mutate(
     mutate: (persisted: PersistedSettings) => PersistedSettings | undefined,
     invalidate?: () => void,
-  ): Promise<boolean> {
-    let wrote = false;
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      const mutated = mutate(persisted);
-      if (!mutated) return;
-      const next: PersistedSettings = { ...mutated, version: SETTINGS_FILE_VERSION };
-      await this.#write(next);
-      this.#loading = Promise.resolve(next);
-      invalidate?.();
-      wrote = true;
-    });
-    return wrote;
-  }
-
-  /**
-   * Runs one settings change at a time. Serializing only the file write is not
-   * enough: a user with more than one provider row can start a second save
-   * before the first lands, and both would read the same stored keys before
-   * either wrote, so the later write would drop the other provider's key.
-   */
-  async #serialize<Result>(operation: () => Promise<Result>): Promise<Result> {
-    const result = this.#mutations.then(operation);
-    // A failed change must not wedge the queue, so the chain forgets its
-    // outcome; the caller still receives the rejection.
-    this.#mutations = result.then(
-      () => undefined,
-      () => undefined,
+  ): Effect.Effect<boolean, PlatformError> {
+    return this.#writes.withPermits(1)(
+      Effect.gen(this, function* () {
+        const persisted = yield* this.#load();
+        const mutated = mutate(persisted);
+        if (!mutated) return false;
+        const next: PersistedSettings = { ...mutated, version: SETTINGS_FILE_VERSION };
+        yield* this.#write(next);
+        this.#held = next;
+        invalidate?.();
+        return true;
+      }),
     );
-    return result;
   }
 
   /**
@@ -1212,23 +1254,27 @@ export class SettingsStore {
    * few seconds, and decrypting on each tick would hit the OS keychain
    * thousands of times a day for a value only the user can change.
    */
-  async #resolveApiKey(provider: CredentialProvider): Promise<ResolvedApiKey> {
-    const cached = this.#resolved.get(provider.id);
-    if (cached) return cached;
-    const stored = await this.#storedApiKey(provider);
-    const fromEnvironment = stored ? undefined : this.#overrides.apiKeys.get(provider.id);
-    const resolved: ResolvedApiKey = stored
-      ? { apiKey: stored, source: CREDENTIAL_SOURCE.ENCRYPTED_FILE }
-      : fromEnvironment
-        ? { apiKey: Redacted.value(fromEnvironment), source: CREDENTIAL_SOURCE.ENVIRONMENT }
-        : { source: CREDENTIAL_SOURCE.NONE };
-    this.#resolved.set(provider.id, resolved);
-    return resolved;
+  #resolveApiKey(provider: CredentialProvider): Effect.Effect<ResolvedApiKey, PlatformError> {
+    return Effect.gen(this, function* () {
+      const cached = this.#resolved.get(provider.id);
+      if (cached) return cached;
+      const stored = yield* this.#storedApiKey(provider);
+      const fromEnvironment = stored ? undefined : this.#overrides.apiKeys.get(provider.id);
+      const resolved: ResolvedApiKey = stored
+        ? { apiKey: stored, source: CREDENTIAL_SOURCE.ENCRYPTED_FILE }
+        : fromEnvironment
+          ? { apiKey: Redacted.value(fromEnvironment), source: CREDENTIAL_SOURCE.ENVIRONMENT }
+          : { source: CREDENTIAL_SOURCE.NONE };
+      this.#resolved.set(provider.id, resolved);
+      return resolved;
+    });
   }
 
-  async #storedApiKey(provider: CredentialProvider): Promise<string | undefined> {
-    const ciphertext = (await this.#load()).apiKeys[provider.id];
-    return ciphertext ? this.#decryptSecret(ciphertext, provider.keyFormat) : undefined;
+  #storedApiKey(provider: CredentialProvider): Effect.Effect<string | undefined, PlatformError> {
+    return Effect.map(this.#load(), (persisted) => {
+      const ciphertext = persisted.apiKeys[provider.id];
+      return ciphertext ? this.#decryptSecret(ciphertext, provider.keyFormat) : undefined;
+    });
   }
 
   /**
@@ -1264,36 +1310,52 @@ export class SettingsStore {
     }
   }
 
-  /** Shares one in-flight read, but lets a transient failure retry next time. */
-  async #load(): Promise<PersistedSettings> {
-    const loading = this.#loading ?? this.#readPersisted();
-    this.#loading = loading;
-    try {
-      return await loading;
-    } catch (error) {
-      // Defaults belong to an absent or corrupt file, both handled by the
-      // reader. An unexpected I/O failure must not become writable defaults:
-      // forget only this failed attempt so the next read can try the file again.
-      if (this.#loading === loading) this.#loading = undefined;
-      throw error;
-    }
-  }
-
-  async #readPersisted(): Promise<PersistedSettings> {
-    const directory = this.#directory();
-    const source = await Runtime.runPromise(this.#runtime)(readSettingsFileText(directory));
-    if (!source) return defaultPersistedSettings();
-    // A corrupt settings file is replaced by the next write rather than
-    // failing app start, so a refusal here falls back to defaults exactly as
-    // an absent file does.
-    return Either.getOrElse(parsePersistedSettingsEither(source), defaultPersistedSettings);
-  }
-
-  /** Only ever called from inside `#serialize`, so writes cannot interleave. */
-  async #write(persisted: PersistedSettings): Promise<void> {
-    const directory = this.#directory();
-    await Runtime.runPromise(this.#runtime)(
-      writeSettingsFileAtomic(directory, `${JSON.stringify(persisted, undefined, 2)}\n`),
+  /**
+   * Shares one read, but lets a transient failure retry next time. The gate is
+   * what shares it: a second reader waits for the first read rather than
+   * making its own, and a read that failed leaves nothing held, so the next
+   * one tries the file again rather than turning an I/O failure into writable
+   * defaults.
+   */
+  #load(): Effect.Effect<PersistedSettings, PlatformError> {
+    return this.#reads.withPermits(1)(
+      Effect.suspend(() =>
+        this.#held
+          ? Effect.succeed(this.#held)
+          : Effect.tap(this.#readPersisted(), (persisted) =>
+              Effect.sync(() => {
+                this.#held = persisted;
+              }),
+            ),
+      ),
     );
+  }
+
+  #readPersisted(): Effect.Effect<PersistedSettings, PlatformError> {
+    return Effect.map(this.#onFileSystem(readSettingsFileText(this.#directory())), (source) =>
+      source === undefined
+        ? defaultPersistedSettings()
+        : // A corrupt settings file is replaced by the next write rather than
+          // failing app start, so a refusal here falls back to defaults exactly
+          // as an absent file does.
+          Either.getOrElse(parsePersistedSettingsEither(source), defaultPersistedSettings),
+    );
+  }
+
+  /** Only ever run inside `#mutate`'s gate, so writes cannot interleave. */
+  #write(persisted: PersistedSettings): Effect.Effect<void, PlatformError> {
+    return this.#onFileSystem(
+      writeSettingsFileAtomic(this.#directory(), `${JSON.stringify(persisted, undefined, 2)}\n`),
+    );
+  }
+
+  /**
+   * The file system this store was handed, provided to its own reads and
+   * writes, so a caller of any method above is left nothing to provide.
+   */
+  #onFileSystem<A>(
+    effect: Effect.Effect<A, PlatformError, FileSystem.FileSystem>,
+  ): Effect.Effect<A, PlatformError> {
+    return Effect.provideService(effect, FileSystem.FileSystem, this.#fileSystem);
   }
 }

--- a/tools/oxlint/anti-slop/effect-edges.json
+++ b/tools/oxlint/anti-slop/effect-edges.json
@@ -43,7 +43,6 @@
     "packages/host/src/compose-conversation.ts",
     "packages/host/src/compose-devices.ts",
     "packages/host/src/service.ts",
-    "packages/host/src/settings-store.ts",
     "packages/host/src/snapshot-roster.ts",
     "packages/host/src/testing/gateway-service.ts",
     "packages/hosted/src/account-call.ts",
@@ -61,6 +60,7 @@
     "apps/web/server/hosted/fiber-runner.ts",
     "packages/brain/src/effect/harness.ts",
     "packages/host/src/compose-live.ts",
+    "packages/host/src/settings-store-awaited.ts",
     "packages/runtime/src/children.effect.ts",
     "packages/runtime/src/queue.effect.ts",
     "packages/voice/src/orchestrator/live-voice-orchestrator.ts"


### PR DESCRIPTION
P12-14c — the settings store's own methods answer Effects.

`SettingsStore`'s `get`/`set`/`setEntry`/`clearEntryIfUnchanged`/`snapshot`/
`readAccount`/`accountSnapshot`/`setAccount`/`clearAccount`/
`accountPreferences`/`applyAccountPreferences`/
`accountPreferencesSyncBaseline`/`setAccountPreferencesSyncBaseline`/
`readVoiceSource`/`readApiKey`/`readStoredApiKey`/`setApiKey`/
`readVaultSyncAccount`/`setVaultSyncAccount`/`resetSettings` and every
calendar method answer Effects over the existing
`readSettingsFileText`/`writeSettingsFileAtomic` effects. The `runtime` option
is gone: the class takes the `FileSystem` service the composer already
resolves and provides it to its own reads and writes, so every method's
context is empty and no caller is left anything to provide. Its two promise
chains are Effect's own: `Effect.unsafeMakeSemaphore(1)` for the write gate and
one for the read gate, keeping what the promise `#loading` kept — a second
reader waits for the first read rather than making its own, and a failed read
leaves nothing held for the next one to inherit.

Callers already shaped as Effects yield the store directly:
`compose-account.ts` (the session manager's store seam drops the three
`Effect.promise` lifts P12-14b left there, `readStoredAccount`, and the
lifetime's `accountSnapshot`), `compose-settings.ts`'s `SETTINGS_SNAPSHOT`
handler and `readStoredAccount`, and `compose-host.ts`'s bootstrap. An
`Effect.orDie` stands where the rejected promise behind the call was already a
defect at that caller.

**The scope split, and why.** The row as tabled also had every remaining
caller yielding the store. On contact that is not one boundary: the calendars,
observation and live composers reach it from promise-shaped bodies, the
settings composer's account-preferences and provider-key-vault chains are
promise queues, `session-action-performer.ts` reads one field inside a promise,
and `@sidecar/voice`'s `VoiceSettings` is a promise-shaped interface
`VoiceCapabilityAssembler` awaits — 154 type errors across three packages, well
past the plan's ~600-line bound, and each of those is its own conversion. So
this PR takes the store and the Effect-shaped callers, and the rest read
through `awaitedSettingsStore` (`packages/host/src/settings-store-awaited.ts`),
a named strangler shim that is the store's own methods run on the runtime the
host is composed on. It takes the store's place on the allowlist — one row
replaces one row — and its ADR entry names the five callers whose landing
takes rows out of it, deleted by P12-14d..g. `sessionReplayState()` and
`arrivalBeat()` stay promises for the same reason and move with their
composers.

The settings vocabulary, the `AppState` document, and the encrypted credential
store's Keychain entry and app name are untouched.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. — check.sh green on this Linux cloud workspace. No
  renderer or UI change; `verify.sh` needs a physical Mac, which this
  environment is not, so nothing was captured or inspected and no
  physical-notch check was performed.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
  only in `admit.ts` and wire's admitted files. — the store's existing
  `SAFETY:`-commented assertions are unchanged; the one retyped cast in
  `session-action-performer.test.ts` names the awaited face in place of the
  store and keeps its comment.
- [x] No `effect` import in an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and
  the ADR's allowlist. — `settings-store.ts` leaves the allowlist (it runs
  nothing now); `settings-store-awaited.ts` enters it as the shim above, with
  its ADR paragraph and table row.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  migrated package.
- [x] Test count equals the pre-PR count or the delta is listed: +2 in
  `@sidecar/host` (71 → 73 in `settings-store.test.ts`), both new `it.effect`
  tests over the store's Effect face — one sequencing a write and the reads
  around it, one pinning that concurrent reads of an unread store read the
  file once. The 71 existing tests keep their bodies and assertions and now
  build their store through the awaited face, which is the same run per call
  they already made; they convert to `it.effect` with the shim's deletion.
- [x] Each hand-rolled file the PR replaces is deleted or marked
  `@deprecated` with its deletion PR named. — `awaitedSettingsStore` and the
  `SettingsComposer.awaitedStore` field are both `@deprecated` naming
  P12-14d..g.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
  root pair stays byte-identical. — none names the store's runtime or its
  promise face; `packages/host`'s pair says the store "reads no environment
  itself — it is handed what was resolved", which still holds. Root pair
  untouched and byte-identical.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. — no dependency change.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
  renderer or a web function opens. — unchanged; the store and its face are
  host-internal and neither is exported from a barrel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a460779a-957c-4ded-987a-3eed8d685287)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)