### PR TITLE
refactor(host): settingsWrite and refusedSettings answer effects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -617,8 +617,11 @@ what took the store's place on the allowlist, and it is the store's own
 methods as the promises their unmigrated callers still hold, run on the
 runtime the host is composed on. The callers are the reason it exists rather
 than the store: the calendars, observation, and live composers reach the
-store from promise-shaped bodies of their own, the settings composer's
-account-preferences and provider-key-vault chains are promise queues,
+store from promise-shaped bodies of their own — the calendars composer's five
+write handlers moved in P12-14d with `settingsWrite` and read it through
+`Effect.promise` at each seam until P12-14e takes the rest of that file — the
+settings composer's account-preferences and provider-key-vault chains are
+promise queues,
 `session-action-performer.ts` reads one field inside a promise, and
 `@sidecar/voice`'s `VoiceSettings` is a promise-shaped interface the
 capability assembler awaits — each its own conversion, and each one's landing

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -407,40 +407,35 @@ export const composeCalendars = (
     const methods: GatewayMethodTable = {
       [GATEWAY_METHOD.CALENDAR_CONNECT_GOOGLE]: (params) =>
         Effect.map(
-          Effect.promise(() =>
-            settings.settingsWrite(
-              async () => {
-                const outcome = await Runtime.runPromise(runtime)(
-                  Effect.scoped(googleCalendarConsent.signInEffect()),
+          settings.settingsWrite(
+            () =>
+              Effect.gen(function* () {
+                const outcome = yield* Effect.scoped(googleCalendarConsent.signInEffect());
+                if ("reason" in outcome) return yield* settings.refusedSettings(outcome.reason);
+                const calendars = yield* Effect.promise(() =>
+                  googleCalendar.listCalendars(outcome.accessToken).catch(() => []),
                 );
-                if ("reason" in outcome) return settings.refusedSettings(outcome.reason);
-                let primaryId: string | undefined;
-                try {
-                  const calendars = await googleCalendar.listCalendars(outcome.accessToken);
-                  primaryId = (calendars.find((candidate) => candidate.primary) ?? calendars[0])
-                    ?.id;
-                } catch {
-                  primaryId = undefined;
-                }
+                const primaryId = (calendars.find((candidate) => candidate.primary) ?? calendars[0])
+                  ?.id;
                 if (!primaryId) {
-                  return settings.refusedSettings(
+                  return yield* settings.refusedSettings(
                     "Google did not answer with the account's calendars.",
                   );
                 }
-                return settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [
-                  primaryId,
-                ]);
-              },
-              (saved) => {
+                return yield* Effect.promise(() =>
+                  settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [primaryId]),
+                );
+              }),
+            (saved) =>
+              Effect.sync(() => {
                 if (saved.reason) return;
                 void loop.refresh();
                 settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
                   calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
                 });
-              },
-              "Could not connect Google Calendar on this system.",
-              reporterOf(params),
-            ),
+              }),
+            "Could not connect Google Calendar on this system.",
+            reporterOf(params),
           ),
           (result) => carried(result),
         ),
@@ -458,19 +453,18 @@ export const composeCalendars = (
         const accountId = params.accountId;
         if (!isWireString(accountId)) return invalid("accountId must be a string");
         return Effect.map(
-          Effect.promise(() =>
-            settings.settingsWrite(
-              () => settingsStore.removeCalendarAccount(accountId),
-              (saved) => {
+          settings.settingsWrite(
+            () => Effect.promise(() => settingsStore.removeCalendarAccount(accountId)),
+            (saved) =>
+              Effect.sync(() => {
                 if (saved.reason) return;
                 void loop.refresh();
                 settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
                   calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
                 });
-              },
-              "Could not disconnect that account on this system.",
-              reporterOf(params),
-            ),
+              }),
+            "Could not disconnect that account on this system.",
+            reporterOf(params),
           ),
           (result) => carried(result),
         );
@@ -480,34 +474,39 @@ export const composeCalendars = (
           const generation = ++appleConnectGeneration;
           let stored = false;
           return Effect.map(
-            Effect.promise(() =>
-              settings.settingsWrite(
-                async () => {
+            settings.settingsWrite(
+              () =>
+                Effect.gen(function* () {
                   // The system's own consent is the whole connect flow, raised by the
                   // helper on the desktop at this press and nowhere else.
-                  const outcome = await appleCalendar.obtainAccess({
-                    openSystemSettings: () =>
-                      void kernel
-                        .openExternalThroughNode(CALENDAR_PRIVACY_PANE_URL)
-                        .catch(kernel.reportOpenFailure),
-                    superseded: () => appleConnectGeneration !== generation,
-                  });
+                  const outcome = yield* Effect.promise(() =>
+                    appleCalendar.obtainAccess({
+                      openSystemSettings: () =>
+                        void kernel
+                          .openExternalThroughNode(CALENDAR_PRIVACY_PANE_URL)
+                          .catch(kernel.reportOpenFailure),
+                      superseded: () => appleConnectGeneration !== generation,
+                    }),
+                  );
                   if (appleConnectGeneration !== generation) {
                     return {
                       status: ACTION_RESULT_STATUS.ACCEPTED,
-                      settings: await settingsStore.snapshot(),
+                      settings: yield* Effect.promise(() => settingsStore.snapshot()),
                     };
                   }
                   if (outcome.access !== APPLE_CALENDAR_ACCESS.FULL) {
-                    return settings.refusedSettings(
+                    return yield* settings.refusedSettings(
                       outcome.failure ?? APPLE_CALENDAR_ACCESS_REFUSAL[outcome.access],
                     );
                   }
                   const seed = outcome.defaultCalendarId ?? outcome.calendars[0]?.id;
                   stored = true;
-                  return settingsStore.connectAppleCalendar(seed ? [seed] : []);
-                },
-                (saved) => {
+                  return yield* Effect.promise(() =>
+                    settingsStore.connectAppleCalendar(seed ? [seed] : []),
+                  );
+                }),
+              (saved) =>
+                Effect.sync(() => {
                   if (saved.reason) return;
                   void loop.refresh();
                   if (stored) {
@@ -515,29 +514,27 @@ export const composeCalendars = (
                       calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
                     });
                   }
-                },
-                "Could not connect Apple Calendar on this system.",
-                reporterOf(params),
-              ),
+                }),
+              "Could not connect Apple Calendar on this system.",
+              reporterOf(params),
             ),
             (result) => carried(result),
           );
         }),
       [GATEWAY_METHOD.CALENDAR_DISCONNECT_APPLE]: (params) =>
         Effect.map(
-          Effect.promise(() =>
-            settings.settingsWrite(
-              () => settingsStore.disconnectAppleCalendar(),
-              (saved) => {
+          settings.settingsWrite(
+            () => Effect.promise(() => settingsStore.disconnectAppleCalendar()),
+            (saved) =>
+              Effect.sync(() => {
                 if (saved.reason) return;
                 void loop.refresh();
                 settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
                   calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
                 });
-              },
-              "Could not disconnect Apple Calendar on this system.",
-              reporterOf(params),
-            ),
+              }),
+            "Could not disconnect Apple Calendar on this system.",
+            reporterOf(params),
           ),
           (result) => carried(result),
         ),
@@ -573,27 +570,27 @@ export const composeCalendars = (
               ?.calendars.some((candidate) => candidate.id === calendarId)
           ) {
             return carried(
-              yield* Effect.promise(() =>
-                settings.refusedSettings(
-                  "That calendar is not one the account's latest list offered.",
-                ),
+              yield* settings.refusedSettings(
+                "That calendar is not one the account's latest list offered.",
               ),
             );
           }
-          const result = yield* Effect.promise(() =>
-            settings.settingsWrite(
-              () => settingsStore.setCalendarSelected(accountId, calendarId, selected),
-              (saved) => {
+          const result = yield* settings.settingsWrite(
+            () =>
+              Effect.promise(() =>
+                settingsStore.setCalendarSelected(accountId, calendarId, selected),
+              ),
+            (saved) =>
+              Effect.sync(() => {
                 if (saved.reason) return;
                 void loop.refresh();
                 settings.recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
                   setting_id: APP_SETTING_ID.CALENDAR_SELECTED,
                   setting_value: selected ? PRODUCT_SETTING_VALUE.ON : PRODUCT_SETTING_VALUE.OFF,
                 });
-              },
-              "Could not save that calendar choice on this system.",
-              reporterOf(params),
-            ),
+              }),
+            "Could not save that calendar choice on this system.",
+            reporterOf(params),
           );
           return carried(result);
         }),

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -32,7 +32,7 @@ import {
 } from "@sidecar/settings";
 import type { SettingsUpdateResult } from "@sidecar/settings/wire";
 import { ACTION_RESULT_STATUS, isWireString, type UnparsedWireValue } from "@sidecar/wire";
-import { Effect, Option } from "effect";
+import { Cause, Effect, Option } from "effect";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
 import type { Composer } from "./composer.js";
 import { startedAndStopped } from "./effect/composer.js";
@@ -76,13 +76,19 @@ export interface SettingsComposer extends Composer {
   recordProductEventOncePerDay: ProductEventSender["recordOncePerDay"];
   emitSettingsSnapshot: (settings: SettingsUpdateResult["settings"], reporter?: string) => void;
   emitSettings: () => Promise<void>;
-  refusedSettings: (reason: string) => Promise<SettingsUpdateResult>;
+  refusedSettings: (reason: string) => Effect.Effect<SettingsUpdateResult>;
+  /**
+   * One settings write and, when it landed, its host side effects and the
+   * change event. The refusal answers for every way the write or its effects
+   * could not be carried, defect included, exactly as the promise door here
+   * caught a rejection from either.
+   */
   settingsWrite: (
-    save: () => Promise<SettingsUpdateResult>,
-    apply: (result: SettingsUpdateResult) => Promise<void> | void,
+    save: () => Effect.Effect<SettingsUpdateResult, unknown>,
+    apply: (result: SettingsUpdateResult) => Effect.Effect<void, unknown>,
     refusal: string,
     reporter: string | undefined,
-  ) => Promise<SettingsUpdateResult>;
+  ) => Effect.Effect<SettingsUpdateResult>;
   reconcileProviderKeyVault: () => void;
   reconcileAccountPreferences: () => Promise<void>;
   /** The developer's own preference write, on its way to the account behind it. */
@@ -377,28 +383,34 @@ export const composeSettings = (): Effect.Effect<
       emitSettingsSnapshot(result.settings);
     }
 
-    const refusedSettings = async (reason: string): Promise<SettingsUpdateResult> => ({
-      status: ACTION_RESULT_STATUS.REJECTED,
-      settings: await awaitedStore.snapshot(),
-      reason,
-    });
+    const refusedSettings = (reason: string): Effect.Effect<SettingsUpdateResult> =>
+      Effect.map(Effect.orDie(store.snapshot()), (settings) => ({
+        status: ACTION_RESULT_STATUS.REJECTED,
+        settings,
+        reason,
+      }));
 
     /** Runs one settings write and, when it landed, its host side effects and the change event. */
-    async function settingsWrite(
-      save: () => Promise<SettingsUpdateResult>,
-      apply: (result: SettingsUpdateResult) => Promise<void> | void,
+    function settingsWrite(
+      save: () => Effect.Effect<SettingsUpdateResult, unknown>,
+      apply: (result: SettingsUpdateResult) => Effect.Effect<void, unknown>,
       refusal: string,
       reporter: string | undefined,
-    ): Promise<SettingsUpdateResult> {
-      let saved: SettingsUpdateResult;
-      try {
-        saved = await save();
-        await apply(saved);
-      } catch {
-        return refusedSettings(refusal);
-      }
-      emitSettingsSnapshot(saved.settings, reporter);
-      return saved;
+    ): Effect.Effect<SettingsUpdateResult> {
+      return Effect.flatMap(save(), (saved) => Effect.as(apply(saved), saved)).pipe(
+        Effect.tap((saved) =>
+          Effect.sync(() => {
+            emitSettingsSnapshot(saved.settings, reporter);
+          }),
+        ),
+        // A write that could not be carried is the row's own refusal rather
+        // than the request's failure, and a step that threw is one of those
+        // ways, which is what the promise door's own `catch` already read it
+        // as. An interruption is not: it is the caller ending this fiber.
+        Effect.catchAllCause((cause) =>
+          Cause.isInterruptedOnly(cause) ? Effect.interrupt : refusedSettings(refusal),
+        ),
+      );
     }
 
     const methods: GatewayMethodTable = {
@@ -414,17 +426,17 @@ export const composeSettings = (): Effect.Effect<
           }
           const parsed = APP_SETTING_SCHEMA[field].guard(params.value);
           if (!parsed.valid) return yield* invalid("value is not the shape that setting takes");
-          const result = yield* Effect.promise(() =>
-            settingsWrite(
-              () => awaitedStore.set(field, parsed.value),
-              async (saved) => {
-                if (saved.reason) return;
-                recordSettingUpdate(field, saved.settings);
-                await applyHostSettingSideEffect(field, saved.settings);
-              },
-              "Could not save that setting on this system.",
-              reporterOf(params),
-            ),
+          const result = yield* settingsWrite(
+            () => store.set(field, parsed.value),
+            (saved) =>
+              saved.reason
+                ? Effect.void
+                : Effect.promise(async () => {
+                    recordSettingUpdate(field, saved.settings);
+                    await applyHostSettingSideEffect(field, saved.settings);
+                  }),
+            "Could not save that setting on this system.",
+            reporterOf(params),
           );
           if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
           return carried(result);
@@ -449,19 +461,18 @@ export const composeSettings = (): Effect.Effect<
           ) {
             return yield* invalid("that project is not one a provider offers");
           }
-          const result = yield* Effect.promise(() =>
-            settingsWrite(
-              // SAFETY: settingEntryGuard validated the entry before it reaches the store.
-              () =>
-                awaitedStore.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
-              async (saved) => {
-                if (saved.reason) return;
-                recordSettingUpdate(field, saved.settings);
-                await applyHostSettingSideEffect(field, saved.settings);
-              },
-              "Could not save that setting on this system.",
-              reporterOf(params),
-            ),
+          const result = yield* settingsWrite(
+            // SAFETY: settingEntryGuard validated the entry before it reaches the store.
+            () => store.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
+            (saved) =>
+              saved.reason
+                ? Effect.void
+                : Effect.promise(async () => {
+                    recordSettingUpdate(field, saved.settings);
+                    await applyHostSettingSideEffect(field, saved.settings);
+                  }),
+            "Could not save that setting on this system.",
+            reporterOf(params),
           );
           if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
           return carried(result);
@@ -471,21 +482,22 @@ export const composeSettings = (): Effect.Effect<
           const scope = params.scope;
           if (!isSettingsResetScope(scope))
             return yield* invalid("scope is not one this build knows");
-          const result = yield* Effect.promise(() =>
-            settingsWrite(
-              () => awaitedStore.resetSettings(scope),
-              async (saved) => {
-                if (saved.reason) return;
-                recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
-                for (const field of APP_SETTING_FIELDS) {
-                  const definition = APP_SETTING_SCHEMA[field];
-                  if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
-                  await applyHostSettingSideEffect(field, saved.settings);
-                }
-              },
-              "Could not reset those settings on this system.",
-              reporterOf(params),
-            ),
+          const result = yield* settingsWrite(
+            () => store.resetSettings(scope),
+            (saved) =>
+              saved.reason
+                ? Effect.void
+                : Effect.promise(async () => {
+                    recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
+                    for (const field of APP_SETTING_FIELDS) {
+                      const definition = APP_SETTING_SCHEMA[field];
+                      if (!("resetScope" in definition) || definition.resetScope !== scope)
+                        continue;
+                      await applyHostSettingSideEffect(field, saved.settings);
+                    }
+                  }),
+            "Could not reset those settings on this system.",
+            reporterOf(params),
           );
           if (!result.reason && resetTouchesAccountPreferences(scope)) pushAccountPreferences();
           return carried(result);
@@ -499,26 +511,30 @@ export const composeSettings = (): Effect.Effect<
           if (apiKey !== undefined && !isWireString(apiKey)) {
             return yield* invalid("apiKey must be a string");
           }
-          const result = yield* Effect.promise(() =>
-            settingsWrite(
-              () => awaitedStore.setApiKey(providerId, apiKey),
-              async (saved) => {
-                if (saved.reason) return;
-                if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
-                  await links().applyVoiceCredential();
-                  await emitSettings();
-                }
-                void vaultSync.keySaved(providerId, apiKey, saved.settings.stored.syncProviderKeys);
-                recordProductEvent(
-                  apiKey?.trim()
-                    ? PRODUCT_EVENT.PROVIDER_CONNECT
-                    : PRODUCT_EVENT.PROVIDER_DISCONNECT,
-                  { connection_id: providerId },
-                );
-              },
-              "Could not save that API key on this system.",
-              reporterOf(params),
-            ),
+          const result = yield* settingsWrite(
+            () => store.setApiKey(providerId, apiKey),
+            (saved) =>
+              saved.reason
+                ? Effect.void
+                : Effect.promise(async () => {
+                    if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
+                      await links().applyVoiceCredential();
+                      await emitSettings();
+                    }
+                    void vaultSync.keySaved(
+                      providerId,
+                      apiKey,
+                      saved.settings.stored.syncProviderKeys,
+                    );
+                    recordProductEvent(
+                      apiKey?.trim()
+                        ? PRODUCT_EVENT.PROVIDER_CONNECT
+                        : PRODUCT_EVENT.PROVIDER_DISCONNECT,
+                      { connection_id: providerId },
+                    );
+                  }),
+            "Could not save that API key on this system.",
+            reporterOf(params),
           );
           return carried(result);
         }),


### PR DESCRIPTION
P12-14d — `settingsWrite` and `refusedSettings` answer Effects.

`settingsWrite(save, apply, refusal, reporter)` takes an effect to save and an
effect to apply and answers `Effect<SettingsUpdateResult>`: the change event is
emitted on the way out, and the row's own refusal answers for every way either
step could not be carried — a failure or a defect, which is what the promise
door's own `catch` already read a rejection from either as. An interruption is
not a refusal: it stands, so a cut fiber is not reported to the row as a write
that failed. `refusedSettings` is the effect beside it, over the store's own
`snapshot`.

Yielding it rather than running it are the four settings handlers
(`SETTINGS_UPDATE`, `SETTINGS_UPDATE_ENTRY`, `SETTINGS_RESET`,
`CREDENTIAL_SET_API_KEY`) and the five calendar write handlers (Google connect
and disconnect, Apple connect and disconnect, calendar selection), each of
which dropped its `Effect.promise(() => settingsWrite(...))` wrapper. The
saves in the settings composer are the store's own effects; the calendars
composer's still cross a promise at each seam (`Effect.promise`), which P12-14e
takes with the rest of that file. Google's consent trip is now yielded inside
the save rather than run on the composer's runtime, so one `Runtime.runPromise`
leaves that file ahead of its own slice.

Scope, honestly: the row as tabled also had the settings composer's
account-preferences and provider-key-vault chains and
`session-action-performer.ts`. Both are left for a later slice and neither
blocks P12-15, which needed `settingsWrite`. The chains are a promise queue
whose collaborators (`AccountPreferencesClient`, `ProviderKeyVaultSync`) are
promise-shaped classes, and their two entry points are fire-and-forget from a
sync callback and a promise body, so converting them is a queue-to-fiber change
with its own callers rather than a mechanical one. The performer's single read
sits inside `guardedRead`, `@sidecar/actions`' own promise door, so it moves
when that door does.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. — check.sh green here. No renderer or UI change;
  `verify.sh` needs a physical Mac, which this cloud workspace is not, so
  nothing was captured or inspected and no physical-notch check was performed.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
  only in `admit.ts` and wire's admitted files.
- [x] No `effect` import in an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and
  the ADR's allowlist. — one `Runtime.runPromise` deleted from
  `compose-calendars.ts` (the Google consent trip); the file keeps its
  allowlist row for the meeting-boundary wake, which this PR does not touch.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  migrated package.
- [x] Test count equals the pre-PR count: 343 in `@sidecar/host` before and
  after; no test added or removed, and none needed editing — the handlers'
  observable answers are unchanged.
- [x] Each hand-rolled file the PR replaces is deleted or marked
  `@deprecated` with its deletion PR named. — none replaced; the
  `awaitedSettingsStore` shim's ADR paragraph now records that the calendars
  composer's write handlers moved here.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
  root pair stays byte-identical. — none names `settingsWrite` or the calendar
  handlers. Root pair untouched and byte-identical.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. — no dependency change.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
  renderer or a web function opens. — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a460779a-957c-4ded-987a-3eed8d685287)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)