### PR TITLE
refactor(host): the calendars composer reads and writes the store as effects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -471,10 +471,22 @@ calendars composer's `startObservation` and `stopObservation` in
 `disarmObservation` over a gate of the same shape, so the held-notice release
 and the Apple access poll are fibers in the scope an arming runs in and what
 the disarm gives back is a finalizer registered before them. That file stays
-on the allowlist for the two runs the gate does not reach: the
-meeting-boundary wake, forked and interrupted from inside an observation pass
-the loop still runs as a promise, and the Google consent trip its own method
-handler runs on the runtime the layer was built on.
+on the allowlist for what the gate does not reach, which P12-14e changed the
+shape of: the Google consent trip is yielded inside its own handler now, and
+what is run there instead is the meeting-boundary wake, forked and
+interrupted from inside an observation pass the loop still runs as a promise,
+and the two effects the composer's own promise-shaped edges start — the
+announcement hold refreshed from the arming's finalizer, and the onboarding
+settle decided from a Gateway handler's synchronous body — each forked onto
+the runtime the layer was built on rather than an ambient default one.
+
+`compose-live.ts` and `compose-devices.ts` each gained one such run in
+P12-14e, on the runtime each already holds: the calendars composer's
+`announcementsQuietNow`, `gateOfferable`, and `meetingQuietUntil` are effects
+since that PR, and the two readers of them that are not — `LiveSessionService`'s
+`quietNow` option and the device row's own presence report — run one there
+until each answers effects itself. Both files were already on this list for
+their own reasons, so neither is a new row.
 
 `compose-account.ts` is off the handed-runtime list since P12-14b: the three
 `Runtime.runPromise` calls that ran the account gate's links for a session
@@ -617,10 +629,11 @@ what took the store's place on the allowlist, and it is the store's own
 methods as the promises their unmigrated callers still hold, run on the
 runtime the host is composed on. The callers are the reason it exists rather
 than the store: the calendars, observation, and live composers reach the
-store from promise-shaped bodies of their own — the calendars composer's five
-write handlers moved in P12-14d with `settingsWrite` and read it through
-`Effect.promise` at each seam until P12-14e takes the rest of that file — the
-settings composer's account-preferences and provider-key-vault chains are
+store from promise-shaped bodies of their own — the calendars composer left
+in P12-14e, and what it still reads through the face is the one setting each
+of its two readers takes as a promise option (`GoogleCalendarReader`'s
+`readAccounts` and `AppleCalendarReader`'s `readConnection`), until each
+reader answers effects itself — the settings composer's account-preferences and provider-key-vault chains are
 promise queues,
 `session-action-performer.ts` reads one field inside a promise, and
 `@sidecar/voice`'s `VoiceSettings` is a promise-shaped interface the

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -26,7 +26,7 @@ import { APP_SETTING_ID, APP_SETTING_SCHEMA } from "@sidecar/settings";
 import type { ObservedAccountCalendars } from "@sidecar/settings/wire";
 import type { BeatKind } from "@sidecar/voice/live-session";
 import { ACTION_RESULT_STATUS, isWireBoolean, isWireString } from "@sidecar/wire";
-import { Duration, Effect, Fiber, Option, Runtime, Schedule, type Scope } from "effect";
+import { Duration, Effect, Either, Fiber, Option, Runtime, Schedule, type Scope } from "effect";
 import {
   APPLE_CALENDAR_ACCESS_REFUSAL,
   type AppleCalendarHelperRun,
@@ -75,7 +75,7 @@ export interface CalendarsComposer extends Composer {
   /** The loop the merge's supervisor enables; the composer never enables it itself. */
   readonly loop: ObservationLoop;
   observedCalendars: () => readonly ObservedAccountCalendars[];
-  announcementsQuietNow: (at: number) => Promise<boolean>;
+  announcementsQuietNow: (at: number) => Effect.Effect<boolean>;
   /**
    * When the meeting hold standing at `at` ends; `null` once the calendars
    * have been observed and none stands; `undefined` before the first
@@ -83,10 +83,10 @@ export interface CalendarsComposer extends Composer {
    * It is the fact the device row reports and nothing decided from it; the
    * manual pause has no end and is no instant.
    */
-  meetingQuietUntil: (at: number) => Promise<number | null | undefined>;
+  meetingQuietUntil: (at: number) => Effect.Effect<number | null | undefined>;
   /** Whether the calendar step of onboarding still stands over the panel. */
   gateOwed: () => boolean;
-  gateOfferable: () => Promise<boolean>;
+  gateOfferable: () => Effect.Effect<boolean>;
   /** Whether the spoken introduction is owed to the signed-in developer, as the onboarding record has it. */
   introductionOwed: () => boolean;
   /** The onboarding record as it stands, for the beats that read their own moments out of it. */
@@ -122,7 +122,11 @@ export const composeCalendars = (
     const runtime = yield* Effect.runtime<never>();
     const home = yield* cadenceHome;
     const { runMode, report, now } = kernel;
-    const settingsStore = settings.awaitedStore;
+    const settingsStore = settings.store;
+    // The two readers below still take a promise for the one setting each
+    // reads, so those two seams keep the face until each reader answers
+    // effects itself.
+    const awaitedSettings = settings.awaitedStore;
     const late = yield* lateService<CalendarsLinks>();
     const links = (): CalendarsLinks => {
       const standing = late.unsafePeek();
@@ -133,7 +137,7 @@ export const composeCalendars = (
     };
 
     const googleCalendar = new GoogleCalendarReader({
-      readAccounts: () => settingsStore.readCalendarAccounts(),
+      readAccounts: () => awaitedSettings.readCalendarAccounts(),
       runtime,
     });
     const googleCalendarConsent = googleCalendarSignIn({
@@ -159,7 +163,7 @@ export const composeCalendars = (
       return result.value;
     };
     const appleCalendar = new AppleCalendarReader({
-      readConnection: () => settingsStore.readAppleCalendarConnection(),
+      readConnection: () => awaitedSettings.readAppleCalendarConnection(),
       runHelper: runAppleCalendarHelper,
       now,
     });
@@ -219,51 +223,54 @@ export const composeCalendars = (
       kernel.emit(GATEWAY_EVENT.CALENDAR_ONBOARDING_CHANGED, { owed });
     }
 
-    async function settleCalendarOnboardingIfConnected(): Promise<void> {
-      if (!calendarOnboardingOwed(onboardingState)) return;
-      const connected = await settingsStore.calendarConnectionStored();
-      if (!connected || !calendarOnboardingOwed(onboardingState)) return;
-      writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
-    }
+    const settleCalendarOnboardingIfConnected = (): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (!calendarOnboardingOwed(onboardingState)) return;
+        const connected = yield* Effect.orDie(settingsStore.calendarConnectionStored());
+        if (!connected || !calendarOnboardingOwed(onboardingState)) return;
+        writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
+      });
 
-    async function calendarGateOfferable(): Promise<boolean> {
-      if (!calendarOnboardingGateOwed()) return false;
-      const snapshot = await settingsStore.snapshot();
-      if (!calendarOnboardingGateOwed()) return false;
-      return snapshot.status.appleCalendarAvailable || snapshot.status.calendarSignInAvailable;
-    }
+    const calendarGateOfferable = (): Effect.Effect<boolean> =>
+      Effect.gen(function* () {
+        if (!calendarOnboardingGateOwed()) return false;
+        const snapshot = yield* Effect.orDie(settingsStore.snapshot());
+        if (!calendarOnboardingGateOwed()) return false;
+        return snapshot.status.appleCalendarAvailable || snapshot.status.calendarSignInAvailable;
+      });
 
-    async function announcementsQuietNow(at: number): Promise<boolean> {
-      const paused = !(await settingsStore.get(APP_SETTING_SCHEMA.announceSessions.field));
-      const inMeeting =
-        !paused &&
-        calendarMeetings !== undefined &&
-        activeMeetingEnd(calendarMeetings, at) !== undefined;
-      // The introduction owed is a hold of its own: nothing else of Luke's
-      // speaks over the greeting, and what was held is re-decided once the
-      // completion takes the hold down, like a meeting's end.
-      const holding =
-        paused ||
-        spokenIntroductionOwed() ||
-        (inMeeting && (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field)));
-      if (holding !== announcementsHeld) {
-        announcementsHeld = holding;
-        kernel.emit(GATEWAY_EVENT.ANNOUNCEMENTS_HELD_CHANGED, { held: holding });
-      }
-      return holding;
-    }
+    const announcementsQuietNow = (at: number): Effect.Effect<boolean> =>
+      Effect.gen(function* () {
+        const paused = !(yield* Effect.orDie(
+          settingsStore.get(APP_SETTING_SCHEMA.announceSessions.field),
+        ));
+        const inMeeting =
+          !paused &&
+          calendarMeetings !== undefined &&
+          activeMeetingEnd(calendarMeetings, at) !== undefined;
+        // The introduction owed is a hold of its own: nothing else of Luke's
+        // speaks over the greeting, and what was held is re-decided once the
+        // completion takes the hold down, like a meeting's end.
+        const holding =
+          paused ||
+          spokenIntroductionOwed() ||
+          (inMeeting &&
+            (yield* Effect.orDie(settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field))));
+        if (holding !== announcementsHeld) {
+          announcementsHeld = holding;
+          kernel.emit(GATEWAY_EVENT.ANNOUNCEMENTS_HELD_CHANGED, { held: holding });
+        }
+        return holding;
+      });
 
-    async function meetingQuietUntil(at: number): Promise<number | null | undefined> {
-      return quietUntilFrom(
-        calendarMeetings,
-        await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field),
-        at,
+    const meetingQuietUntil = (at: number): Effect.Effect<number | null | undefined> =>
+      Effect.map(
+        Effect.orDie(settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field)),
+        (quietDuringMeetings) => quietUntilFrom(calendarMeetings, quietDuringMeetings, at),
       );
-    }
 
-    async function refreshAnnouncementHold(): Promise<void> {
-      await announcementsQuietNow(now());
-    }
+    const refreshAnnouncementHold = (): Effect.Effect<void> =>
+      Effect.asVoid(announcementsQuietNow(now()));
 
     /**
      * The meeting-boundary wake is a one-shot fiber rather than a fixed
@@ -339,28 +346,33 @@ export const composeCalendars = (
       run: refreshCalendarMeetings,
     });
 
-    async function pollAppleCalendarAccess(): Promise<void> {
-      if (!(await settingsStore.readAppleCalendarConnection())) return;
-      let access: string | undefined;
-      try {
-        access = await appleCalendar.status();
-      } catch (error) {
-        if (!appleAccessProbeFailing) {
+    const pollAppleCalendarAccess = (): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (!(yield* Effect.orDie(settingsStore.readAppleCalendarConnection()))) return;
+        // The probe's own failure is read out of the failure channel rather
+        // than caught around the yield: a rejection lifted into a fiber is a
+        // defect no `try` here would see, and one failed probe must not end
+        // the poll the schedule is repeating.
+        const probed = yield* Effect.either(
+          Effect.tryPromise({ try: () => appleCalendar.status(), catch: (error) => error }),
+        );
+        const access = Either.getOrUndefined(probed);
+        if (Either.isLeft(probed) && !appleAccessProbeFailing) {
+          const error = probed.left;
           report(
             `Calendar access probe failed: ${error instanceof Error ? error.message : String(error)}`,
           );
         }
-      }
-      appleAccessProbeFailing = access === undefined;
-      if (access === undefined) return;
-      const drawnRevoked =
-        observedCalendars.find((held) => held.accountId === APPLE_CALENDAR_ID)?.revoked === true;
-      const probeRevoked = access !== APPLE_CALENDAR_ACCESS.FULL;
-      if (probeRevoked !== drawnRevoked) {
-        report(`Calendar access now reads ${access}; running a pass.`);
-        void loop.refresh();
-      }
-    }
+        appleAccessProbeFailing = access === undefined;
+        if (access === undefined) return;
+        const drawnRevoked =
+          observedCalendars.find((held) => held.accountId === APPLE_CALENDAR_ID)?.revoked === true;
+        const probeRevoked = access !== APPLE_CALENDAR_ACCESS.FULL;
+        if (probeRevoked !== drawnRevoked) {
+          report(`Calendar access now reads ${access}; running a pass.`);
+          void loop.refresh();
+        }
+      });
 
     /**
      * The two remaining timers are fixed-interval `Schedule`s forked into the
@@ -383,7 +395,7 @@ export const composeCalendars = (
           appleCalendar.forget();
           links().dropBriefings();
           kernel.emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: [] });
-          void refreshAnnouncementHold();
+          Runtime.runFork(runtime)(refreshAnnouncementHold());
         }),
       );
       yield* Effect.forkScoped(
@@ -395,7 +407,7 @@ export const composeCalendars = (
       if (process.platform === "darwin" && runMode.observesProviders) {
         yield* Effect.forkScoped(
           Effect.schedule(
-            Effect.promise(() => pollAppleCalendarAccess()),
+            pollAppleCalendarAccess(),
             Schedule.spaced(Duration.millis(APPLE_ACCESS_POLL_INTERVAL_MS)),
           ),
         );
@@ -422,9 +434,9 @@ export const composeCalendars = (
                     "Google did not answer with the account's calendars.",
                   );
                 }
-                return yield* Effect.promise(() =>
-                  settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [primaryId]),
-                );
+                return yield* settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [
+                  primaryId,
+                ]);
               }),
             (saved) =>
               Effect.sync(() => {
@@ -454,7 +466,7 @@ export const composeCalendars = (
         if (!isWireString(accountId)) return invalid("accountId must be a string");
         return Effect.map(
           settings.settingsWrite(
-            () => Effect.promise(() => settingsStore.removeCalendarAccount(accountId)),
+            () => settingsStore.removeCalendarAccount(accountId),
             (saved) =>
               Effect.sync(() => {
                 if (saved.reason) return;
@@ -491,7 +503,7 @@ export const composeCalendars = (
                   if (appleConnectGeneration !== generation) {
                     return {
                       status: ACTION_RESULT_STATUS.ACCEPTED,
-                      settings: yield* Effect.promise(() => settingsStore.snapshot()),
+                      settings: yield* settingsStore.snapshot(),
                     };
                   }
                   if (outcome.access !== APPLE_CALENDAR_ACCESS.FULL) {
@@ -501,9 +513,7 @@ export const composeCalendars = (
                   }
                   const seed = outcome.defaultCalendarId ?? outcome.calendars[0]?.id;
                   stored = true;
-                  return yield* Effect.promise(() =>
-                    settingsStore.connectAppleCalendar(seed ? [seed] : []),
-                  );
+                  return yield* settingsStore.connectAppleCalendar(seed ? [seed] : []);
                 }),
               (saved) =>
                 Effect.sync(() => {
@@ -524,7 +534,7 @@ export const composeCalendars = (
       [GATEWAY_METHOD.CALENDAR_DISCONNECT_APPLE]: (params) =>
         Effect.map(
           settings.settingsWrite(
-            () => Effect.promise(() => settingsStore.disconnectAppleCalendar()),
+            () => settingsStore.disconnectAppleCalendar(),
             (saved) =>
               Effect.sync(() => {
                 if (saved.reason) return;
@@ -576,10 +586,7 @@ export const composeCalendars = (
             );
           }
           const result = yield* settings.settingsWrite(
-            () =>
-              Effect.promise(() =>
-                settingsStore.setCalendarSelected(accountId, calendarId, selected),
-              ),
+            () => settingsStore.setCalendarSelected(accountId, calendarId, selected),
             (saved) =>
               Effect.sync(() => {
                 if (saved.reason) return;
@@ -648,7 +655,7 @@ export const composeCalendars = (
         if (onboardingState?.calendarOnboardingRequiredAt !== undefined) return;
         const at = new Date(now()).toISOString();
         writeOnboardingState({ introductionRequiredAt: at, calendarOnboardingRequiredAt: at });
-        void settleCalendarOnboardingIfConnected();
+        Runtime.runFork(runtime)(settleCalendarOnboardingIfConnected());
       },
       armObservation: observation.arm,
       disarmObservation: observation.disarm,
@@ -660,7 +667,7 @@ export const composeCalendars = (
       // is its start alone.
       lifetime: Effect.sync(() => {
         onboardingState = onboarding.read();
-        void settleCalendarOnboardingIfConnected();
+        Runtime.runFork(runtime)(settleCalendarOnboardingIfConnected());
       }),
     };
   });

--- a/packages/host/src/compose-devices.ts
+++ b/packages/host/src/compose-devices.ts
@@ -15,7 +15,7 @@ import {
 } from "@sidecar/hosted";
 import { cadenceGate } from "@sidecar/runtime/effect";
 import { text, type WireRecord } from "@sidecar/wire";
-import { Duration, Effect, Fiber, Schedule, type Scope } from "effect";
+import { Duration, Effect, Fiber, Runtime, Schedule, type Scope } from "effect";
 import type { AccountComposer } from "./compose-account.js";
 import type { CalendarsComposer } from "./compose-calendars.js";
 import type { Composer } from "./composer.js";
@@ -317,6 +317,10 @@ export const composeDevices = (
 ): Effect.Effect<DevicesComposer, never, HostKernelTag | MachinePresenceReader | Scope.Scope> =>
   Effect.gen(function* () {
     const { account, calendars } = dependencies;
+    // The device row's presence is read as a promise by the cadence below, so
+    // the calendars composer's own effect is run on the host's runtime here
+    // until that report is an effect too.
+    const runtime = yield* Effect.runtime<never>();
     const kernel: HostKernel = yield* HostKernelTag;
     const machinePresence = yield* MachinePresenceReader;
     const { runMode, report, now } = kernel;
@@ -341,7 +345,7 @@ export const composeDevices = (
         const at = now();
         return {
           activeUntil: activeUntilFrom(machinePresence.read?.(), at),
-          quietUntil: await calendars.meetingQuietUntil(at),
+          quietUntil: await Runtime.runPromise(runtime)(calendars.meetingQuietUntil(at)),
         };
       },
       report,

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -278,14 +278,10 @@ export const hostAssemblyLayer: Layer.Layer<
       [GATEWAY_METHOD.CLIENT_BOOTSTRAP]: () =>
         Effect.gen(function* () {
           const snapshot = yield* Effect.orDie(settings.store.snapshot());
-          const [quiet, replay] = yield* Effect.promise(() =>
-            Promise.all([
-              account.capabilitiesActive()
-                ? calendars.announcementsQuietNow(now())
-                : Promise.resolve(false),
-              account.sessionReplayState(),
-            ]),
-          );
+          const quiet = account.capabilitiesActive()
+            ? yield* calendars.announcementsQuietNow(now())
+            : false;
+          const replay = yield* Effect.promise(() => account.sessionReplayState());
           const workspaceProjectDefaults = account.capabilitiesActive()
             ? yield* Effect.orDie(
                 settings.store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),

--- a/packages/host/src/compose-live.ts
+++ b/packages/host/src/compose-live.ts
@@ -132,7 +132,8 @@ export const composeLive = (
     // The service's own idle, settle, and finalize timers, over the Effect
     // runtime this composition runs on rather than Node's own `setTimeout`, so
     // a test driving a `TestClock` drives them too.
-    const timers = liveSessionTimersOnRuntime(yield* Effect.runtime<never>());
+    const runtime = yield* Effect.runtime<never>();
+    const timers = liveSessionTimersOnRuntime(runtime);
 
     function markFirstAnnouncementSpoken(): void {
       const onboardingState = calendars.onboarding();
@@ -154,7 +155,10 @@ export const composeLive = (
       record: liveRecord,
       conversationEntries: () => brain.store.thread().entries(),
       roster: () => voiceRoster(observation.rosterForClients()),
-      quietNow: () => calendars.announcementsQuietNow(now()),
+      // `LiveSessionService` asks for the hold as a promise, so the calendars
+      // composer's effect is run on the host's own runtime here until that
+      // service answers effects itself.
+      quietNow: () => Runtime.runPromise(runtime)(calendars.announcementsQuietNow(now())),
       releaseHeldBriefings: (held) => links().releaseHeld(held),
       emit: (change) => kernel.emit(GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED, carried(change)),
       now: timers.now,
@@ -216,7 +220,7 @@ export const composeLive = (
       // The greeting comes first and speaks in its own session; the beats are
       // asked for again by the completion that takes the introduction down.
       if (calendars.introductionOwed()) return;
-      if (await calendars.gateOfferable()) {
+      if (await Runtime.runPromise(runtime)(calendars.gateOfferable())) {
         service.speakBeat({ kind: PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING, decidedAt: now() });
         return;
       }


### PR DESCRIPTION
P12-14e — the calendars composer reads and writes the store as Effects.

`settingsStore` in `compose-calendars.ts` is `settings.store` now, not
`settings.awaitedStore`. Its own reads are effects —
`settleCalendarOnboardingIfConnected`, `calendarGateOfferable`,
`announcementsQuietNow`, `meetingQuietUntil`, `refreshAnnouncementHold`, and
the Apple access poll — and its five write handlers save through the store
directly, dropping the `Effect.promise` each carried since P12-14d. The Apple
access poll is now the effect the `Schedule` repeats rather than a promise
wrapped in one.

Three members of `CalendarsComposer` answer effects with them:
`announcementsQuietNow`, `meetingQuietUntil`, and `gateOfferable`.
`compose-host.ts`'s bootstrap yields the first directly. The two readers that
are not effects yet — `LiveSessionService`'s `quietNow` option and the device
row's own presence report — run one on the runtime their composer already
holds (`compose-live.ts`, `compose-devices.ts`), both files already on the
ADR's allowlist for their own reasons, so no new row. Inside the calendars
composer the two promise-shaped edges that start an effect (the announcement
hold refreshed from the arming's finalizer, the onboarding settle decided from
a Gateway handler's synchronous body) are `Runtime.runFork` onto the layer's
own runtime rather than `void`-ed promises, and the Google consent trip's run
is gone as of P12-14d.

What still reads through the awaited face here is exactly one setting per
calendar reader: `GoogleCalendarReader`'s `readAccounts` and
`AppleCalendarReader`'s `readConnection`, both promise-shaped options of
classes whose own conversion is its own change. The ADR's shim paragraph says
so.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. — check.sh green here. No renderer or UI change;
  `verify.sh` needs a physical Mac, which this cloud workspace is not, so
  nothing was captured or inspected and no physical-notch check was performed.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
  only in `admit.ts` and wire's admitted files.
- [x] No `effect` import in an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and
  the ADR's allowlist. — the runs added (two in `compose-live.ts`, one in
  `compose-devices.ts`, two forks in `compose-calendars.ts`) are all in files
  already on the allowlist, and each file's ADR paragraph now says what it
  runs and what would take it off.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  migrated package.
- [x] Test count equals the pre-PR count: 343 in `@sidecar/host` before and
  after; no test added, removed, or edited — what the composer answers is
  unchanged, only how a caller waits for it.
- [x] Each hand-rolled file the PR replaces is deleted or marked
  `@deprecated` with its deletion PR named. — none replaced; the
  `awaitedSettingsStore` shim's ADR paragraph now names the two reader options
  as all this file still holds it for.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
  root pair stays byte-identical. — the root pair's calendar rules are about
  what is read and what it may decide, both unchanged; `packages/host`'s pair
  describes the composer's three timers, also unchanged. Root pair untouched
  and byte-identical.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. — no dependency change.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
  renderer or a web function opens. — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a460779a-957c-4ded-987a-3eed8d685287)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)