### PR TITLE
refactor(host): the preferences and vault chains as queues a fiber drains

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -546,7 +546,11 @@ callers hold, the settings side effects and the account gate in
 `compose-host.ts` — runs `transitionVoiceSource`'s effect on the captured
 runtime rather than the ambient default one. It is deleted once
 `applyVoiceCredential` itself answers an effect and its callers yield it
-instead of awaiting it. `startCapabilities` and `stopCapabilities` are the links' own effects behind
+instead of awaiting it. P12-14h put a second one back beside it: the session
+manager's `onChange` is a synchronous callback with no fiber to yield on, and
+`settings.emitSettings()` is an effect since that PR, so the settings change it
+asks for is a `Runtime.runFork` onto the same captured runtime. That one goes
+when `onChange` itself answers an effect. `startCapabilities` and `stopCapabilities` are the links' own effects behind
 an `Effect.suspend`, which is what keeps a link read no earlier than the call
 that needs it, and `onSignOut` is `releaseDevice` directly. The three account reads and
 writes it lifted at that seam are lifted no longer: P12-14c took the store
@@ -684,14 +688,16 @@ store from promise-shaped bodies of their own — the calendars composer left
 in P12-14e, and what it still reads through the face is the one setting each
 of its two readers takes as a promise option (`GoogleCalendarReader`'s
 `readAccounts` and `AppleCalendarReader`'s `readConnection`), until each
-reader answers effects itself — the settings composer's account-preferences and provider-key-vault chains are
-promise queues, and
-`session-action-performer.ts` reads one field inside a promise —
-each its own conversion, and each one's landing takes rows out of this face.
-`@sidecar/voice`'s `VoiceSettings` left in P12-14g: it is an Effect-returning
-interface now, the same shape `SettingsStore`'s own methods answer, so
-`compose-account.ts` hands `VoiceCapabilityAssembler` the store directly. It
-is deleted by P12-14h, when the last of them yields the store directly.
+reader answers effects itself — and `session-action-performer.ts` reads one
+field inside a promise — each its own conversion, and each one's landing takes
+rows out of this face. `@sidecar/voice`'s `VoiceSettings` left in P12-14g: it
+is an Effect-returning interface now, the same shape `SettingsStore`'s own
+methods answer, so `compose-account.ts` hands `VoiceCapabilityAssembler` the
+store directly. The settings composer's own account-preferences and
+provider-key-vault chains left in P12-14h: both are `Queue`s drained by a fiber
+of the composer's lifetime scope, and every step either takes is the store's
+own effect. It is deleted by P12-14i, when the last of them yields the store
+directly.
 
 `tracedModelAdapter` in `packages/devtrace/src/brain-trace.ts` is on the same
 terms as `runCall`, permanently: the traced `respond` still answers the
@@ -1171,9 +1177,10 @@ design decision stated as such:
 | `FiberStoreRunner`/`fiberStoreRunner`, the promise face the four promise-shaped contracts above `apps/web`'s effects are handed (it replaced `HostedStoreRun` and `BrainHostSeams.run`, which P10-16 deleted) | P10-16 | once eve's tool and stream contracts, the turn event stream, and the voice service's socket-driven compositions answer effects themselves |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | with the last promise-shaped hosted route (`conversation-read.ts`, `events.ts`, `devices-vault-app.ts`); P10-16 moved every route it converted onto `RateBrake.check` |
 | `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P12-15 — the fence must stay synchronous, so this is bookkeeping rather than a scheduled deletion |
-| `compose-account.ts`'s runs of the account gate's links on the host's own runtime | P7-13b | P12-14b (see also below, put back in P12-14g for `applyVoiceCredential`) |
-| `awaitedSettingsStore`, the settings store's own methods as the promises their unmigrated callers hold | P12-14c | P12-14h — the calendars, observation, and live composers (P12-14e), the settings composer's promise chains (P12-14d), the session action performer, and `@sidecar/voice`'s `VoiceSettings` (P12-14g) have each left; P12-14h deletes the file |
+| `compose-account.ts`'s runs of the account gate's links on the host's own runtime | P7-13b | P12-14b (see also below, put back in P12-14g for `applyVoiceCredential` and in P12-14h for `emitSettings`) |
+| `awaitedSettingsStore`, the settings store's own methods as the promises their unmigrated callers hold | P12-14c | P12-14i — the calendars, observation, and live composers (P12-14e), `@sidecar/voice`'s `VoiceSettings` (P12-14g), and the settings composer's own chains (P12-14h) have each left; what still holds it is the observation and live composers' remaining reads, the two calendar readers' promise options, and the session action performer |
 | `compose-account.ts`'s run of `transitionVoiceSource` on the host's own runtime, for `applyVoiceCredential`'s still-`Promise<void>` callers | P12-14g | once `applyVoiceCredential` itself answers an effect |
+| `compose-account.ts`'s fork of `settings.emitSettings()` on the host's own runtime, from the session manager's synchronous `onChange` | P12-14h | once `AccountSessionManager`'s `onChange` answers an effect |
 | `AppStateStore`'s `subscribe`, the Set-backed callback face beside `snapshot`/`update`/`touch` | P8-02 | P8-07 |
 | `LinearCredentials`'s renewal, running `singleFlightEffect` over a handed-in `Runtime` | P7-06 | once `LinearCredentials` answers an Effect itself |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08b |

--- a/packages/host/src/account-preferences-client.test.ts
+++ b/packages/host/src/account-preferences-client.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import type { AccountPreferences } from "@sidecar/settings";
 import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
-import { test } from "vitest";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
 
 const PREFERENCES_ANSWER = {
@@ -37,94 +37,107 @@ function client(options: Partial<ConstructorParameters<typeof AccountPreferences
   });
 }
 
-test("reads account preferences as a bearer-authenticated GET", async () => {
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
-  ]);
+it.effect("reads account preferences as a bearer-authenticated GET", () =>
+  Effect.gen(function* () {
+    const { requests, fetchLike } = service([
+      () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
+    ]);
 
-  const answer = await client({ httpClient: fakeHttpClientLayer(fetchLike) }).readPreferences();
-  assert.deepEqual(answer, {
-    preferences: PREFERENCES_ANSWER.preferences,
-    hasStoredSnapshot: true,
-  });
+    const answer = yield* client({ httpClient: fakeHttpClientLayer(fetchLike) }).readPreferences();
+    assert.deepEqual(answer, {
+      preferences: PREFERENCES_ANSWER.preferences,
+      hasStoredSnapshot: true,
+    });
 
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/account/preferences");
-  assert.equal(request?.init?.method, "GET");
-  assert.equal(request?.init?.body, undefined);
-  assert.equal(new Headers(request?.init?.headers).get("authorization"), "Bearer token-1");
-  assert.equal(new Headers(request?.init?.headers).get("content-type"), null);
-});
+    const [request] = requests;
+    assert.equal(request?.url, "https://tryluke.dev/api/account/preferences");
+    assert.equal(request?.init?.method, "GET");
+    assert.equal(request?.init?.body, undefined);
+    assert.equal(new Headers(request?.init?.headers).get("authorization"), "Bearer token-1");
+    assert.equal(new Headers(request?.init?.headers).get("content-type"), null);
+  }),
+);
 
-test("reads a missing hosted row as an empty snapshot without a stored marker", async () => {
-  const { fetchLike } = service([
-    () => new Response(JSON.stringify({ preferences: {} }), { status: 200 }),
-  ]);
+it.effect("reads a missing hosted row as an empty snapshot without a stored marker", () =>
+  Effect.gen(function* () {
+    const { fetchLike } = service([
+      () => new Response(JSON.stringify({ preferences: {} }), { status: 200 }),
+    ]);
 
-  assert.deepEqual(await client({ httpClient: fakeHttpClientLayer(fetchLike) }).readPreferences(), {
-    preferences: {},
-    hasStoredSnapshot: false,
-  });
-});
+    assert.deepEqual(
+      yield* client({ httpClient: fakeHttpClientLayer(fetchLike) }).readPreferences(),
+      {
+        preferences: {},
+        hasStoredSnapshot: false,
+      },
+    );
+  }),
+);
 
-test("writes account preferences as a full snapshot", async () => {
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
-  ]);
+it.effect("writes account preferences as a full snapshot", () =>
+  Effect.gen(function* () {
+    const { requests, fetchLike } = service([
+      () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
+    ]);
 
-  const answer = await client({ httpClient: fakeHttpClientLayer(fetchLike) }).writePreferences({
-    voice: "marin",
-    defaultWorkspaceProvider: "conductor",
-  });
-  assert.deepEqual(answer, {
-    preferences: PREFERENCES_ANSWER.preferences,
-    hasStoredSnapshot: true,
-  });
+    const answer = yield* client({ httpClient: fakeHttpClientLayer(fetchLike) }).writePreferences({
+      voice: "marin",
+      defaultWorkspaceProvider: "conductor",
+    });
+    assert.deepEqual(answer, {
+      preferences: PREFERENCES_ANSWER.preferences,
+      hasStoredSnapshot: true,
+    });
 
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/account/preferences");
-  assert.equal(request?.init?.method, "PUT");
-  assert.equal(new Headers(request?.init?.headers).get("content-type"), "application/json");
-  assert.deepEqual(JSON.parse(String(request?.init?.body)), {
-    preferences: { voice: "marin", defaultWorkspaceProvider: "conductor" },
-  });
-});
+    const [request] = requests;
+    assert.equal(request?.url, "https://tryluke.dev/api/account/preferences");
+    assert.equal(request?.init?.method, "PUT");
+    assert.equal(new Headers(request?.init?.headers).get("content-type"), "application/json");
+    assert.deepEqual(JSON.parse(String(request?.init?.body)), {
+      preferences: { voice: "marin", defaultWorkspaceProvider: "conductor" },
+    });
+  }),
+);
 
-test("a malformed account preferences payload never travels", async () => {
-  const { requests, fetchLike } = service([]);
+it.effect("a malformed account preferences payload never travels", () =>
+  Effect.gen(function* () {
+    const { requests, fetchLike } = service([]);
 
-  // SAFETY: This deliberately bypasses the public AccountPreferences type to verify the runtime guard.
-  const malformed = { voiceHotkey: "Command+Space" } as AccountPreferences;
+    // SAFETY: This deliberately bypasses the public AccountPreferences type to verify the runtime guard.
+    const malformed = { voiceHotkey: "Command+Space" } as AccountPreferences;
 
-  assert.equal(
-    await client({ httpClient: fakeHttpClientLayer(fetchLike) }).writePreferences(malformed),
-    undefined,
-  );
-  assert.equal(requests.length, 0);
-});
+    assert.equal(
+      yield* client({ httpClient: fakeHttpClientLayer(fetchLike) }).writePreferences(malformed),
+      undefined,
+    );
+    assert.equal(requests.length, 0);
+  }),
+);
 
-test("a refusal and a snapshot the settings vocabulary does not admit read as no answer", async () => {
-  const refused = client({
-    httpClient: fakeHttpClientLayer(
-      async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
-    ),
-  });
-  assert.equal(await refused.writePreferences({ voice: "sage" }), undefined);
+it.effect("a refusal and a snapshot the settings vocabulary does not admit read as no answer", () =>
+  Effect.gen(function* () {
+    const refused = client({
+      httpClient: fakeHttpClientLayer(
+        async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
+      ),
+    });
+    assert.equal(yield* refused.writePreferences({ voice: "sage" }), undefined);
 
-  const malformed = client({
-    httpClient: fakeHttpClientLayer(
-      async () => new Response(JSON.stringify({ preferences: "none" }), { status: 200 }),
-    ),
-  });
-  assert.equal(await malformed.readPreferences(), undefined);
+    const malformed = client({
+      httpClient: fakeHttpClientLayer(
+        async () => new Response(JSON.stringify({ preferences: "none" }), { status: 200 }),
+      ),
+    });
+    assert.equal(yield* malformed.readPreferences(), undefined);
 
-  const unknownField = client({
-    httpClient: fakeHttpClientLayer(
-      async () =>
-        new Response(JSON.stringify({ preferences: { voiceHotkey: "Command+Space" } }), {
-          status: 200,
-        }),
-    ),
-  });
-  assert.equal(await unknownField.readPreferences(), undefined);
-});
+    const unknownField = client({
+      httpClient: fakeHttpClientLayer(
+        async () =>
+          new Response(JSON.stringify({ preferences: { voiceHotkey: "Command+Space" } }), {
+            status: 200,
+          }),
+      ),
+    });
+    assert.equal(yield* unknownField.readPreferences(), undefined);
+  }),
+);

--- a/packages/host/src/account-preferences-client.ts
+++ b/packages/host/src/account-preferences-client.ts
@@ -1,14 +1,15 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
 import {
-  type AccountCall,
+  type AccountCallEffects,
   type AccountToken,
   accountBearer,
-  createAccountCall,
+  accountCall,
   HOSTED_SERVICE_PATH,
 } from "@sidecar/hosted";
 import { type AccountPreferences, accountPreferencesFromWire } from "@sidecar/settings";
 import { HTTP_METHOD, isRecord, isWireNumber, type UnparsedWireValue } from "@sidecar/wire";
-import type { Layer } from "effect";
+import { Effect, type Layer } from "effect";
 
 export interface AccountPreferencesAnswer {
   preferences: AccountPreferences;
@@ -43,35 +44,48 @@ function accountPreferencesAnswerFromWire(
  * makes its requests through.
  */
 export class AccountPreferencesClient {
-  readonly #call: AccountCall;
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
 
   constructor(options: AccountPreferencesClientOptions) {
-    this.#call = createAccountCall({
+    this.#call = accountCall({
       baseUrl: options.serviceBaseUrl,
       credential: accountBearer(options),
-      httpClient: options.httpClient,
       requestTimeoutMs: options.requestTimeoutMs,
     });
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
   }
 
-  readPreferences(): Promise<AccountPreferencesAnswer | undefined> {
-    return this.#call.ask(
-      { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES },
-      accountPreferencesAnswerFromWire,
+  readPreferences(): Effect.Effect<AccountPreferencesAnswer | undefined> {
+    return this.#over(
+      this.#call.read(
+        { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES },
+        accountPreferencesAnswerFromWire,
+      ),
     );
   }
 
-  writePreferences(preferences: AccountPreferences): Promise<AccountPreferencesAnswer | undefined> {
+  writePreferences(
+    preferences: AccountPreferences,
+  ): Effect.Effect<AccountPreferencesAnswer | undefined> {
     // SAFETY: AccountPreferences is JSON-compatible; the strict parser protects this runtime boundary.
     const parsed = accountPreferencesFromWire(preferences as UnparsedWireValue);
-    if (parsed === undefined) return Promise.resolve(undefined);
-    return this.#call.ask(
-      {
-        method: HTTP_METHOD.PUT,
-        path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES,
-        body: JSON.stringify({ preferences: parsed }),
-      },
-      accountPreferencesAnswerFromWire,
+    if (parsed === undefined) return Effect.succeed(undefined);
+    return this.#over(
+      this.#call.read(
+        {
+          method: HTTP_METHOD.PUT,
+          path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES,
+          body: JSON.stringify({ preferences: parsed }),
+        },
+        accountPreferencesAnswerFromWire,
+      ),
     );
+  }
+
+  #over<Answer>(
+    effect: Effect.Effect<Answer, never, HttpClient.HttpClient>,
+  ): Effect.Effect<Answer> {
+    return Effect.provide(effect, this.#client);
   }
 }

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -99,8 +99,10 @@ export const composeAccount = (
     // The runtime the host is being built on, threaded through
     // `VoiceCapabilityAssembler` to every model adapter it builds, so the
     // promise each of those still answers is run on the host's own runtime
-    // rather than on an ambient default one. This composer runs nothing on it
-    // itself.
+    // rather than on an ambient default one, and what this composer runs on it
+    // itself: `applyVoiceCredential`'s transition below, and the settings
+    // change the account's own `onChange` asks for from a synchronous body
+    // that has no fiber to yield on.
     const runtime = yield* Effect.runtime<never>();
     const late = yield* lateService<AccountLinks>();
     const links = (): AccountLinks => {
@@ -144,7 +146,11 @@ export const composeAccount = (
         if (previousAccountKey !== nextAccountKey) settings.forgetAccountPreferenceHydration();
         if (signedIn && !wasSignedIn) links().onFirstSignIn();
         kernel.emit(GATEWAY_EVENT.ACCOUNT_CHANGED, carried(account));
-        void settings.emitSettings();
+        // The settings change on the host's own runtime rather than an ambient
+        // default one, forked because nothing here waits for it, exactly as
+        // the promise it replaced was not waited for. The run allowlist entry
+        // (`docs/adr/0001-effect.md`) goes when `onChange` answers an Effect.
+        Runtime.runFork(runtime)(settings.emitSettings());
         void emitSessionReplay();
         if (signedIn && !wasSignedIn) {
           settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -197,13 +197,13 @@ export const hostAssemblyLayer: Layer.Layer<
      * this opened.
      */
     const openCapabilities = Effect.gen(function* () {
-      if (account.signedIn()) void settings.reconcileAccountPreferences();
+      if (account.signedIn()) yield* settings.reconcileAccountPreferences();
       yield* Effect.promise(() => account.applyVoiceCredential());
-      yield* Effect.promise(() => settings.emitSettings());
+      yield* settings.emitSettings();
       if (!account.capabilitiesActive()) return;
       observation.startObservation();
       yield* capabilities.arm;
-      if (account.signedIn()) settings.reconcileProviderKeyVault();
+      if (account.signedIn()) yield* settings.reconcileProviderKeyVault();
       void live.requestOnboardingBeat();
     });
 
@@ -215,7 +215,7 @@ export const hostAssemblyLayer: Layer.Layer<
       live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.ARRIVAL);
       live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING);
       yield* Effect.promise(() => account.applyVoiceCredential());
-      yield* Effect.promise(() => settings.emitSettings());
+      yield* settings.emitSettings();
     });
 
     // Every edge a composer could not take as a constructor argument, in one

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -1,3 +1,4 @@
+import type { PlatformError } from "@effect/platform/Error";
 import * as FileSystem from "@effect/platform/FileSystem";
 import {
   PRODUCT_EVENT,
@@ -32,7 +33,7 @@ import {
 } from "@sidecar/settings";
 import type { SettingsUpdateResult } from "@sidecar/settings/wire";
 import { ACTION_RESULT_STATUS, isWireString, type UnparsedWireValue } from "@sidecar/wire";
-import { Cause, Effect, Option } from "effect";
+import { Cause, Effect, Option, Queue } from "effect";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
 import type { Composer } from "./composer.js";
 import { startedAndStopped } from "./effect/composer.js";
@@ -40,7 +41,7 @@ import { HostKernelTag, lateService } from "./effect/kernel.js";
 import { AppIdentity, type Environment, SecretCipher } from "./effect/seams.js";
 import { settingsOverrides } from "./effect/settings-overrides.js";
 import { heldProductEvents } from "./held-product-events.js";
-import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync.js";
+import { providerKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync.js";
 import { hostSettingSideEffects } from "./settings-side-effects.js";
 import { SettingsStore, type StoredAccount } from "./settings-store.js";
 import { type AwaitedSettingsStore, awaitedSettingsStore } from "./settings-store-awaited.js";
@@ -75,7 +76,7 @@ export interface SettingsComposer extends Composer {
   /** One count per provider per day, as the observation pass makes it. */
   recordProductEventOncePerDay: ProductEventSender["recordOncePerDay"];
   emitSettingsSnapshot: (settings: SettingsUpdateResult["settings"], reporter?: string) => void;
-  emitSettings: () => Promise<void>;
+  emitSettings: () => Effect.Effect<void>;
   refusedSettings: (reason: string) => Effect.Effect<SettingsUpdateResult>;
   /**
    * One settings write and, when it landed, its host side effects and the
@@ -89,9 +90,13 @@ export interface SettingsComposer extends Composer {
     refusal: string,
     reporter: string | undefined,
   ) => Effect.Effect<SettingsUpdateResult>;
-  reconcileProviderKeyVault: () => void;
-  reconcileAccountPreferences: () => Promise<void>;
-  /** The developer's own preference write, on its way to the account behind it. */
+  reconcileProviderKeyVault: () => Effect.Effect<void>;
+  reconcileAccountPreferences: () => Effect.Effect<void>;
+  /**
+   * The developer's own preference write, on its way to the account behind it,
+   * offered rather than run: the observation composer asks for one from a
+   * promise-shaped body that has no fiber to yield on.
+   */
   pushAccountPreferences: () => void;
   /** The account behind the hydrated preferences changed; the next push hydrates again. */
   forgetAccountPreferenceHydration: () => void;
@@ -175,53 +180,79 @@ export const composeSettings = (): Effect.Effect<
           : Effect.succeed(undefined),
       refreshAccount: () => links().refreshAccount(),
       readAccountKey: () =>
-        Effect.tryPromise(() => readAccountPreferenceAccountKey()).pipe(
-          Effect.orElseSucceed(() => undefined),
-        ),
+        readAccountPreferenceAccountKey().pipe(Effect.orElseSucceed(() => undefined)),
     });
-    const vaultSync = new ProviderKeyVaultSync({
+    const vaultSync = yield* providerKeyVaultSync({
       vault: hostedVault,
-      readStoredApiKey: (providerId) => awaitedStore.readStoredApiKey(providerId),
-      account: async () => {
-        const held = await awaitedStore.readAccount();
-        if (!held) return undefined;
-        const vaultAccount: VaultSyncAccount = { email: held.email };
-        if (held.id) vaultAccount.id = held.id;
-        return vaultAccount;
-      },
+      readStoredApiKey: (providerId) => store.readStoredApiKey(providerId),
+      account: () =>
+        Effect.map(store.readAccount(), (held) => {
+          if (!held) return undefined;
+          const vaultAccount: VaultSyncAccount = { email: held.email };
+          if (held.id) vaultAccount.id = held.id;
+          return vaultAccount;
+        }),
       tenant: {
-        read: () => awaitedStore.readVaultSyncAccount(),
-        write: (accountKey) => awaitedStore.setVaultSyncAccount(accountKey),
+        read: () => store.readVaultSyncAccount(),
+        write: (accountKey) => store.setVaultSyncAccount(accountKey),
       },
     });
 
     let accountPreferencesHydratedAccount: string | undefined;
-    let accountPreferencesSync: Promise<void> = Promise.resolve();
 
-    function reconcileProviderKeyVault(): void {
-      void awaitedStore
-        .snapshot()
-        .then((settings) =>
-          settings.stored.syncProviderKeys ? vaultSync.apply(true, { claim: false }) : undefined,
-        );
+    /**
+     * One account-preferences action and the name its failure is reported
+     * under. Every one of them rides this queue, so a reconcile and a push
+     * cannot interleave into a snapshot that agrees with neither, exactly as
+     * the one promise chain they were written on held them.
+     */
+    interface AccountPreferencesAction {
+      readonly label: string;
+      readonly work: Effect.Effect<void, unknown>;
     }
+    const accountPreferencesActions = yield* Queue.unbounded<AccountPreferencesAction>();
 
-    async function readAccountPreferenceAccountKey(): Promise<string | undefined> {
-      return (await awaitedStore.readAccount())?.email;
-    }
+    /**
+     * An action offered rather than run: the hands and loops that ask for one
+     * are not all fibers, and an offer onto an unbounded queue is what every
+     * one of them can make where it stands.
+     */
+    const queueAccountPreferencesSync = (
+      label: string,
+      work: Effect.Effect<void, unknown>,
+    ): void => {
+      Queue.unsafeOffer(accountPreferencesActions, { label, work });
+    };
 
-    function queueAccountPreferencesSync(label: string, work: () => Promise<void>): Promise<void> {
-      const queued = accountPreferencesSync.then(work, work).catch((error) => {
-        report(
-          `Account preferences ${label} failed: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      });
-      accountPreferencesSync = queued.then(
-        () => undefined,
-        () => undefined,
+    const failureReason = (cause: Cause.Cause<unknown>): string => {
+      const error = Cause.squash(cause);
+      return error instanceof Error ? error.message : String(error);
+    };
+
+    /** The queue drained one action at a time, for as long as the fiber running it stands. */
+    const drainAccountPreferencesSync = Queue.take(accountPreferencesActions).pipe(
+      Effect.flatMap(({ label, work }) =>
+        Effect.catchAllCause(work, (cause) =>
+          // An interruption is this fiber being ended rather than the action
+          // going wrong; every other way it could not be carried, a defect
+          // included, is the line the promise chain's own `catch` reported.
+          Cause.isInterruptedOnly(cause)
+            ? Effect.interrupt
+            : Effect.sync(() => {
+                report(`Account preferences ${label} failed: ${failureReason(cause)}`);
+              }),
+        ),
+      ),
+      Effect.forever,
+    );
+
+    const reconcileProviderKeyVault = (): Effect.Effect<void> =>
+      Effect.flatMap(Effect.orDie(store.snapshot()), (settings) =>
+        settings.stored.syncProviderKeys ? vaultSync.apply(true, { claim: false }) : Effect.void,
       );
-      return queued;
-    }
+
+    const readAccountPreferenceAccountKey = (): Effect.Effect<string | undefined, PlatformError> =>
+      Effect.map(store.readAccount(), (account) => account?.email);
 
     function accountPreferencesEmpty(preferences: AccountPreferences): boolean {
       return Object.keys(preferences).length === 0;
@@ -231,15 +262,16 @@ export const composeSettings = (): Effect.Effect<
       return JSON.stringify(left) === JSON.stringify(right);
     }
 
-    async function accountPreferenceHydrationBaseline(
+    const accountPreferenceHydrationBaseline = (
       accountEmail: string,
-    ): Promise<AccountPreferences> {
-      const baseline = await awaitedStore.accountPreferencesSyncBaseline(accountEmail);
-      if (baseline !== undefined) return baseline;
-      const preferences = await awaitedStore.accountPreferences();
-      await awaitedStore.setAccountPreferencesSyncBaseline(accountEmail, preferences);
-      return preferences;
-    }
+    ): Effect.Effect<AccountPreferences, PlatformError> =>
+      Effect.gen(function* () {
+        const baseline = yield* store.accountPreferencesSyncBaseline(accountEmail);
+        if (baseline !== undefined) return baseline;
+        const preferences = yield* store.accountPreferences();
+        yield* store.setAccountPreferencesSyncBaseline(accountEmail, preferences);
+        return preferences;
+      });
 
     function isAccountPreferenceField(field: AppSettingField): field is AccountPreferenceField {
       return ACCOUNT_PREFERENCE_FIELDS.some((candidate) => candidate === field);
@@ -252,74 +284,82 @@ export const composeSettings = (): Effect.Effect<
       });
     }
 
-    async function reconcileAccountPreferences(): Promise<void> {
-      return queueAccountPreferencesSync("reconcile", async () => {
-        const accountKey = await readAccountPreferenceAccountKey();
-        if (!accountKey) return;
-        await hydrateAccountPreferences(accountKey);
+    const reconcileAccountPreferences = (): Effect.Effect<void> =>
+      Effect.sync(() => {
+        queueAccountPreferencesSync(
+          "reconcile",
+          Effect.gen(function* () {
+            const accountKey = yield* readAccountPreferenceAccountKey();
+            if (!accountKey) return;
+            yield* hydrateAccountPreferences(accountKey);
+          }),
+        );
       });
-    }
 
-    async function hydrateAccountPreferences(accountKey: string): Promise<boolean> {
-      const baseline = await accountPreferenceHydrationBaseline(accountKey);
-      if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-      const remote = await accountPreferencesClient.readPreferences();
-      if (!remote || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
+    const hydrateAccountPreferences = (accountKey: string): Effect.Effect<boolean, PlatformError> =>
+      Effect.gen(function* () {
+        const baseline = yield* accountPreferenceHydrationBaseline(accountKey);
+        if ((yield* readAccountPreferenceAccountKey()) !== accountKey) return false;
+        const remote = yield* accountPreferencesClient.readPreferences();
+        if (!remote || (yield* readAccountPreferenceAccountKey()) !== accountKey) return false;
 
-      if (!remote.hasStoredSnapshot) {
-        const preferences = await awaitedStore.accountPreferences();
-        if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-        if (!accountPreferencesEmpty(preferences)) {
-          const written = await accountPreferencesClient.writePreferences(preferences);
-          if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
+        if (!remote.hasStoredSnapshot) {
+          const preferences = yield* store.accountPreferences();
+          if ((yield* readAccountPreferenceAccountKey()) !== accountKey) return false;
+          if (!accountPreferencesEmpty(preferences)) {
+            const written = yield* accountPreferencesClient.writePreferences(preferences);
+            if (!written || (yield* readAccountPreferenceAccountKey()) !== accountKey) return false;
+          }
+          if (!(yield* store.setAccountPreferencesSyncBaseline(accountKey, preferences))) {
+            return false;
+          }
+          accountPreferencesHydratedAccount = accountKey;
+          return true;
         }
-        if (!(await awaitedStore.setAccountPreferencesSyncBaseline(accountKey, preferences))) {
-          return false;
-        }
+
+        const saved = yield* store.applyAccountPreferences(remote.preferences, {
+          accountEmail: accountKey,
+          preferences: baseline,
+        });
+        if ((yield* readAccountPreferenceAccountKey()) !== accountKey) return false;
         accountPreferencesHydratedAccount = accountKey;
+        const preferences = yield* store.accountPreferences();
+        if ((yield* readAccountPreferenceAccountKey()) !== accountKey) return false;
+        if (saved.changed.length > 0) {
+          yield* applyAccountPreferenceSideEffects(saved, saved.changed);
+        }
+        if (!accountPreferencesSame(preferences, remote.preferences)) {
+          const written = yield* accountPreferencesClient.writePreferences(preferences);
+          if (!written || (yield* readAccountPreferenceAccountKey()) !== accountKey) return true;
+        }
+        yield* store.setAccountPreferencesSyncBaseline(accountKey, preferences);
         return true;
-      }
-
-      const saved = await awaitedStore.applyAccountPreferences(remote.preferences, {
-        accountEmail: accountKey,
-        preferences: baseline,
       });
-      if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-      accountPreferencesHydratedAccount = accountKey;
-      const preferences = await awaitedStore.accountPreferences();
-      if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-      if (saved.changed.length > 0) {
-        await applyAccountPreferenceSideEffects(saved, saved.changed);
-      }
-      if (!accountPreferencesSame(preferences, remote.preferences)) {
-        const written = await accountPreferencesClient.writePreferences(preferences);
-        if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return true;
-      }
-      await awaitedStore.setAccountPreferencesSyncBaseline(accountKey, preferences);
-      return true;
-    }
 
     function pushAccountPreferences(): void {
-      void queueAccountPreferencesSync("write", async () => {
-        const accountKey = await readAccountPreferenceAccountKey();
-        if (!accountKey) return;
-        if (
-          accountPreferencesHydratedAccount !== accountKey &&
-          !(await hydrateAccountPreferences(accountKey))
-        ) {
-          return;
-        }
-        const preferences = await awaitedStore.accountPreferences();
-        if (
-          (await readAccountPreferenceAccountKey()) !== accountKey ||
-          accountPreferencesHydratedAccount !== accountKey
-        ) {
-          return;
-        }
-        const written = await accountPreferencesClient.writePreferences(preferences);
-        if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return;
-        await awaitedStore.setAccountPreferencesSyncBaseline(accountKey, preferences);
-      });
+      queueAccountPreferencesSync(
+        "write",
+        Effect.gen(function* () {
+          const accountKey = yield* readAccountPreferenceAccountKey();
+          if (!accountKey) return;
+          if (
+            accountPreferencesHydratedAccount !== accountKey &&
+            !(yield* hydrateAccountPreferences(accountKey))
+          ) {
+            return;
+          }
+          const preferences = yield* store.accountPreferences();
+          if (
+            (yield* readAccountPreferenceAccountKey()) !== accountKey ||
+            accountPreferencesHydratedAccount !== accountKey
+          ) {
+            return;
+          }
+          const written = yield* accountPreferencesClient.writePreferences(preferences);
+          if (!written || (yield* readAccountPreferenceAccountKey()) !== accountKey) return;
+          yield* store.setAccountPreferencesSyncBaseline(accountKey, preferences);
+        }),
+      );
     }
 
     const recordProductEvent: RecordProductEvent = (name, properties) =>
@@ -335,9 +375,10 @@ export const composeSettings = (): Effect.Effect<
       });
     }
 
-    async function emitSettings(): Promise<void> {
-      emitSettingsSnapshot(await awaitedStore.snapshot());
-    }
+    const emitSettings = (): Effect.Effect<void> =>
+      Effect.map(Effect.orDie(store.snapshot()), (snapshot) => {
+        emitSettingsSnapshot(snapshot);
+      });
 
     function recordSettingUpdate(
       field: AppSettingField,
@@ -355,33 +396,33 @@ export const composeSettings = (): Effect.Effect<
       setVoice: (voice) => links().setVoice(voice),
       applyVoiceCredential: () => links().applyVoiceCredential(),
       reconcileSpeech: () => links().reconcileSpeech(),
-      applyVaultSync: (syncProviderKeys) => void vaultSync.apply(syncProviderKeys, { claim: true }),
+      applyVaultSync: (syncProviderKeys) => vaultSync.apply(syncProviderKeys, { claim: true }),
       emitSettings,
     });
 
-    async function applyHostSettingSideEffect(
+    const applyHostSettingSideEffect = (
       field: AppSettingField,
       settings: SettingsUpdateResult["settings"],
-    ): Promise<void> {
-      await sideEffects[APP_SETTING_SCHEMA[field].sideEffect]({ settings: settings.stored });
-    }
+    ): Effect.Effect<void> =>
+      sideEffects[APP_SETTING_SCHEMA[field].sideEffect]({ settings: settings.stored });
 
-    async function applyAccountPreferenceSideEffects(
+    const applyAccountPreferenceSideEffects = (
       result: SettingsUpdateResult,
       changed: readonly AccountPreferenceField[],
-    ): Promise<void> {
-      for (const field of changed) {
-        await applyHostSettingSideEffect(field, result.settings);
-      }
-      if (
-        changed.includes(APP_SETTING_SCHEMA.workspaceAgentDefaults.field) ||
-        changed.includes(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field) ||
-        changed.includes(APP_SETTING_SCHEMA.workspaceProjectDefaults.field)
-      ) {
-        await links().broadcastWorkspaceProjects();
-      }
-      emitSettingsSnapshot(result.settings);
-    }
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        for (const field of changed) {
+          yield* applyHostSettingSideEffect(field, result.settings);
+        }
+        if (
+          changed.includes(APP_SETTING_SCHEMA.workspaceAgentDefaults.field) ||
+          changed.includes(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field) ||
+          changed.includes(APP_SETTING_SCHEMA.workspaceProjectDefaults.field)
+        ) {
+          yield* Effect.promise(() => links().broadcastWorkspaceProjects());
+        }
+        emitSettingsSnapshot(result.settings);
+      });
 
     const refusedSettings = (reason: string): Effect.Effect<SettingsUpdateResult> =>
       Effect.map(Effect.orDie(store.snapshot()), (settings) => ({
@@ -431,9 +472,9 @@ export const composeSettings = (): Effect.Effect<
             (saved) =>
               saved.reason
                 ? Effect.void
-                : Effect.promise(async () => {
+                : Effect.gen(function* () {
                     recordSettingUpdate(field, saved.settings);
-                    await applyHostSettingSideEffect(field, saved.settings);
+                    yield* applyHostSettingSideEffect(field, saved.settings);
                   }),
             "Could not save that setting on this system.",
             reporterOf(params),
@@ -467,9 +508,9 @@ export const composeSettings = (): Effect.Effect<
             (saved) =>
               saved.reason
                 ? Effect.void
-                : Effect.promise(async () => {
+                : Effect.gen(function* () {
                     recordSettingUpdate(field, saved.settings);
-                    await applyHostSettingSideEffect(field, saved.settings);
+                    yield* applyHostSettingSideEffect(field, saved.settings);
                   }),
             "Could not save that setting on this system.",
             reporterOf(params),
@@ -487,13 +528,13 @@ export const composeSettings = (): Effect.Effect<
             (saved) =>
               saved.reason
                 ? Effect.void
-                : Effect.promise(async () => {
+                : Effect.gen(function* () {
                     recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
                     for (const field of APP_SETTING_FIELDS) {
                       const definition = APP_SETTING_SCHEMA[field];
                       if (!("resetScope" in definition) || definition.resetScope !== scope)
                         continue;
-                      await applyHostSettingSideEffect(field, saved.settings);
+                      yield* applyHostSettingSideEffect(field, saved.settings);
                     }
                   }),
             "Could not reset those settings on this system.",
@@ -516,12 +557,12 @@ export const composeSettings = (): Effect.Effect<
             (saved) =>
               saved.reason
                 ? Effect.void
-                : Effect.promise(async () => {
+                : Effect.gen(function* () {
                     if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
-                      await links().applyVoiceCredential();
-                      await emitSettings();
+                      yield* Effect.promise(() => links().applyVoiceCredential());
+                      yield* emitSettings();
                     }
-                    void vaultSync.keySaved(
+                    yield* vaultSync.keySaved(
                       providerId,
                       apiKey,
                       saved.settings.stored.syncProviderKeys,
@@ -575,17 +616,26 @@ export const composeSettings = (): Effect.Effect<
       link: (next) => {
         late.unsafeSet(next);
       },
-      lifetime: startedAndStopped(
-        Effect.sync(() => {
-          void awaitedStore.snapshot();
-          productEvents.arm();
-          productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: identity.appVersion });
-          productEvents.markDayActive();
-          if (runMode.sendsNetwork) productEvents.start();
-        }),
-        Effect.sync(() => {
-          productEvents.stop();
-        }),
-      ),
+      lifetime: Effect.gen(function* () {
+        yield* startedAndStopped(
+          Effect.sync(() => {
+            productEvents.arm();
+            productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: identity.appVersion });
+            productEvents.markDayActive();
+            if (runMode.sendsNetwork) productEvents.start();
+          }),
+          Effect.sync(() => {
+            productEvents.stop();
+          }),
+        );
+        // The settings read once so the file is warm for the composers built
+        // after this one, waited on by none of them.
+        yield* Effect.forkScoped(Effect.ignore(store.snapshot()));
+        // The two chains this composer holds, each drained by a fiber of the
+        // composer's own lifetime scope: the scope closing interrupts both
+        // before the stop above gives back what the start took.
+        yield* Effect.forkScoped(drainAccountPreferencesSync);
+        yield* Effect.forkScoped(vaultSync.actions);
+      }),
     };
   });

--- a/packages/host/src/provider-key-vault-sync.ts
+++ b/packages/host/src/provider-key-vault-sync.ts
@@ -1,6 +1,7 @@
 import type { CredentialProviderId } from "@sidecar/credentials";
 import type { HostedVaultClient } from "@sidecar/hosted";
 import { CLOUD_AGENT_PROVIDER_ID, isCloudAgentProviderId } from "@sidecar/session";
+import { Cause, Effect, Queue } from "effect";
 
 /** The signed-in account, by the names the tenant record may hold it under. */
 export interface VaultSyncAccount {
@@ -16,6 +17,51 @@ function tenantName(account: VaultSyncAccount): string {
 /** Whether a tenant record names this account, under either of its names. */
 function accountAnswersTo(account: VaultSyncAccount, tenant: string): boolean {
   return tenant === account.id || tenant === account.email;
+}
+
+export interface ProviderKeyVaultSyncOptions {
+  vault: HostedVaultClient;
+  /**
+   * The key stored in Luke's own encrypted file, and never one resolved
+   * from the launch environment: an environment key was configured for
+   * this machine's shell, not entered into Luke, so the sweep may not
+   * send it anywhere.
+   */
+  readStoredApiKey: (
+    providerId: CredentialProviderId,
+  ) => Effect.Effect<string | undefined, unknown>;
+  /** The signed-in account's identity, or nothing signed out. */
+  account: () => Effect.Effect<VaultSyncAccount | undefined, unknown>;
+  /** Which account this Mac's keys were last synced for, persisted. */
+  tenant: {
+    read: () => Effect.Effect<string | undefined, unknown>;
+    write: (accountKey: string) => Effect.Effect<void, unknown>;
+  };
+}
+
+export interface ProviderKeyVaultSync {
+  /** A save landed locally; mirror it while the switch is on. */
+  keySaved: (
+    providerId: CredentialProviderId,
+    apiKey: string | undefined,
+    syncOn: boolean,
+  ) => Effect.Effect<void>;
+  /**
+   * The switch moved. Off deletes every synced copy, blindly, because a
+   * delete of nothing answers `deleted: false` and costs nothing. On sweeps
+   * every vault-provider key stored here up — at the flip itself as a claim
+   * for the signed-in account, and at capabilities starting as the standing
+   * reconcile, which uploads only for the account the keys were last synced
+   * for. Whose account stands is re-read before every key, so a sweep that
+   * outlives its sign-in writes nothing more.
+   */
+  apply: (syncOn: boolean, options: { claim: boolean }) => Effect.Effect<void>;
+  /**
+   * The one chain every action rides, for as long as the fiber running it
+   * stands. A failure is dropped rather than carried forward: every action is
+   * quiet on its own, and one that failed must not still the hands behind it.
+   */
+  readonly actions: Effect.Effect<never>;
 }
 
 /**
@@ -40,109 +86,83 @@ function accountAnswersTo(account: VaultSyncAccount, tenant: string): boolean {
  * save — and every sweep re-checks whose account stands before each key it
  * touches, so an action outliving its sign-out goes quiet instead of landing on
  * whoever signed in next.
+ *
+ * Every action rides one queue, so saves and switch flips land on the vault in
+ * the order the hands took them: a save mid-sweep, or a quick off-and-on of
+ * the switch, cannot interleave into a vault that agrees with neither.
  */
-export class ProviderKeyVaultSync {
-  readonly #vault: HostedVaultClient;
-  readonly #readStoredApiKey: (providerId: CredentialProviderId) => Promise<string | undefined>;
-  readonly #account: () => Promise<VaultSyncAccount | undefined>;
-  readonly #tenant: {
-    read: () => Promise<string | undefined>;
-    write: (accountKey: string) => Promise<void>;
-  };
-  /**
-   * Every action rides one chain, so saves and switch flips land on the vault
-   * in the order the hands took them: a save mid-sweep, or a quick off-and-on
-   * of the switch, cannot interleave into a vault that agrees with neither.
-   */
-  #actions: Promise<void> = Promise.resolve();
+export const providerKeyVaultSync = (
+  options: ProviderKeyVaultSyncOptions,
+): Effect.Effect<ProviderKeyVaultSync> =>
+  Effect.gen(function* () {
+    const queued = yield* Queue.unbounded<Effect.Effect<void, unknown>>();
+    const enqueue = (act: Effect.Effect<void, unknown>): Effect.Effect<void> =>
+      Effect.asVoid(Queue.offer(queued, act));
 
-  constructor(options: {
-    vault: HostedVaultClient;
-    /**
-     * The key stored in Luke's own encrypted file, and never one resolved
-     * from the launch environment: an environment key was configured for
-     * this machine's shell, not entered into Luke, so the sweep may not
-     * send it anywhere.
-     */
-    readStoredApiKey: (providerId: CredentialProviderId) => Promise<string | undefined>;
-    /** The signed-in account's identity, or nothing signed out. */
-    account: () => Promise<VaultSyncAccount | undefined>;
-    /** Which account this Mac's keys were last synced for, persisted. */
-    tenant: {
-      read: () => Promise<string | undefined>;
-      write: (accountKey: string) => Promise<void>;
-    };
-  }) {
-    this.#vault = options.vault;
-    this.#readStoredApiKey = options.readStoredApiKey;
-    this.#account = options.account;
-    this.#tenant = options.tenant;
-  }
+    const keySaved: ProviderKeyVaultSync["keySaved"] = (providerId, apiKey, syncOn) =>
+      enqueue(
+        Effect.gen(function* () {
+          if (!isCloudAgentProviderId(providerId)) return;
+          const key = apiKey?.trim();
+          if (!key) {
+            // A cleared key clears its synced copy regardless of the switch: the
+            // switch governs what goes up, never what may keep standing after
+            // the developer deleted the thing it mirrors.
+            yield* Effect.promise(() => options.vault.deleteKey(providerId));
+            return;
+          }
+          if (!syncOn) return;
+          const account = yield* options.account();
+          if (account === undefined) return;
+          const stored = yield* Effect.promise(() => options.vault.storeKey(providerId, key));
+          // Their own key, saved by their own hand: the save is also the claim.
+          if (stored) yield* options.tenant.write(tenantName(account));
+        }),
+      );
 
-  #enqueue(act: () => Promise<void>): Promise<void> {
-    const settled = this.#actions.then(act);
-    // The chain never carries a refusal forward: every action is quiet on its
-    // own, and one that threw must not still a queue of later hands.
-    this.#actions = settled.catch(() => undefined);
-    return settled;
-  }
+    const apply: ProviderKeyVaultSync["apply"] = (syncOn, { claim }) =>
+      enqueue(
+        Effect.gen(function* () {
+          if (!syncOn) {
+            for (const providerId of Object.values(CLOUD_AGENT_PROVIDER_ID)) {
+              yield* Effect.promise(() => options.vault.deleteKey(providerId));
+            }
+            return;
+          }
+          const account = yield* options.account();
+          if (account === undefined) return;
+          const tenant = yield* options.tenant.read();
+          // The record may hold either of the account's names — the id when the
+          // sign-in carried one, else the address — and an identity refresh may
+          // fill the id in later, so a match on either keeps the standing
+          // reconcile standing rather than orphaning it on the stronger name.
+          if (!claim && tenant !== undefined && !accountAnswersTo(account, tenant)) return;
+          let storedAny = false;
+          for (const providerId of Object.values(CLOUD_AGENT_PROVIDER_ID)) {
+            if ((yield* options.account())?.email !== account.email) return;
+            const key = (yield* options.readStoredApiKey(providerId))?.trim();
+            if (key && (yield* Effect.promise(() => options.vault.storeKey(providerId, key)))) {
+              storedAny = true;
+            }
+          }
+          // Only a sweep that actually moved a key claims the tenant: an empty
+          // one says nothing about whose keys these are, and a claim it made
+          // would let a passing sign-in inherit whatever is saved here later.
+          if (storedAny) yield* options.tenant.write(tenantName(account));
+        }),
+      );
 
-  /** A save landed locally; mirror it while the switch is on. */
-  keySaved(providerId: CredentialProviderId, apiKey: string | undefined, syncOn: boolean) {
-    return this.#enqueue(async () => {
-      if (!isCloudAgentProviderId(providerId)) return;
-      const key = apiKey?.trim();
-      if (!key) {
-        // A cleared key clears its synced copy regardless of the switch: the
-        // switch governs what goes up, never what may keep standing after
-        // the developer deleted the thing it mirrors.
-        await this.#vault.deleteKey(providerId);
-        return;
-      }
-      if (!syncOn) return;
-      const account = await this.#account();
-      if (account === undefined) return;
-      const stored = await this.#vault.storeKey(providerId, key);
-      // Their own key, saved by their own hand: the save is also the claim.
-      if (stored) await this.#tenant.write(tenantName(account));
-    });
-  }
+    const actions = Queue.take(queued).pipe(
+      Effect.flatMap((act) =>
+        Effect.catchAllCause(act, (cause) =>
+          // An interruption is the fiber being ended rather than an action
+          // going wrong, so it stands; every other way an action could not be
+          // carried, a defect included, is the quiet the next hand retries.
+          Cause.isInterruptedOnly(cause) ? Effect.interrupt : Effect.void,
+        ),
+      ),
+      Effect.forever,
+    );
 
-  /**
-   * The switch moved. Off deletes every synced copy, blindly, because a
-   * delete of nothing answers `deleted: false` and costs nothing. On sweeps
-   * every vault-provider key stored here up — at the flip itself as a claim
-   * for the signed-in account, and at capabilities starting as the standing
-   * reconcile, which uploads only for the account the keys were last synced
-   * for. Whose account stands is re-read before every key, so a sweep that
-   * outlives its sign-in writes nothing more.
-   */
-  apply(syncOn: boolean, options: { claim: boolean }): Promise<void> {
-    return this.#enqueue(async () => {
-      if (!syncOn) {
-        for (const providerId of Object.values(CLOUD_AGENT_PROVIDER_ID)) {
-          await this.#vault.deleteKey(providerId);
-        }
-        return;
-      }
-      const account = await this.#account();
-      if (account === undefined) return;
-      const tenant = await this.#tenant.read();
-      // The record may hold either of the account's names — the id when the
-      // sign-in carried one, else the address — and an identity refresh may
-      // fill the id in later, so a match on either keeps the standing
-      // reconcile standing rather than orphaning it on the stronger name.
-      if (!options.claim && tenant !== undefined && !accountAnswersTo(account, tenant)) return;
-      let storedAny = false;
-      for (const providerId of Object.values(CLOUD_AGENT_PROVIDER_ID)) {
-        if ((await this.#account())?.email !== account.email) return;
-        const key = (await this.#readStoredApiKey(providerId))?.trim();
-        if (key && (await this.#vault.storeKey(providerId, key))) storedAny = true;
-      }
-      // Only a sweep that actually moved a key claims the tenant: an empty
-      // one says nothing about whose keys these are, and a claim it made
-      // would let a passing sign-in inherit whatever is saved here later.
-      if (storedAny) await this.#tenant.write(tenantName(account));
-    });
-  }
-}
+    return { keySaved, apply, actions };
+  });

--- a/packages/host/src/settings-side-effects.ts
+++ b/packages/host/src/settings-side-effects.ts
@@ -3,13 +3,14 @@ import {
   type SettingSideEffectId,
   type StoredAppSettings,
 } from "@sidecar/settings";
+import { Effect } from "effect";
 
 /** What one host-side effect is handed: the snapshot the write just stored. */
 interface HostSettingSideEffectContext {
   readonly settings: StoredAppSettings;
 }
 
-type HostSettingSideEffect = (context: HostSettingSideEffectContext) => Promise<void> | void;
+type HostSettingSideEffect = (context: HostSettingSideEffectContext) => Effect.Effect<void>;
 
 /**
  * Every side effect a setting can have, over the whole of the id set. Total on
@@ -20,15 +21,15 @@ type HostSettingSideEffect = (context: HostSettingSideEffectContext) => Promise<
 type HostSettingSideEffects = Readonly<Record<SettingSideEffectId, HostSettingSideEffect>>;
 
 /** An effect this side has nothing to do about, whichever side owns it. */
-const noHostSettingSideEffect: HostSettingSideEffect = () => {};
+const noHostSettingSideEffect: HostSettingSideEffect = () => Effect.void;
 
 /** What the host's own side effects reach in the concerns around them. */
 export interface HostSettingSideEffectDependencies {
   setVoice: (voice: StoredAppSettings["voice"]) => void;
   applyVoiceCredential: () => Promise<void>;
   reconcileSpeech: () => void;
-  applyVaultSync: (syncProviderKeys: boolean) => void;
-  emitSettings: () => Promise<void>;
+  applyVaultSync: (syncProviderKeys: boolean) => Effect.Effect<void>;
+  emitSettings: () => Effect.Effect<void>;
 }
 
 /**
@@ -46,12 +47,21 @@ export function hostSettingSideEffects(dependencies: HostSettingSideEffectDepend
     [SETTING_SIDE_EFFECT.TALK_HOTKEY]: noHostSettingSideEffect,
     [SETTING_SIDE_EFFECT.STOP_HOTKEY]: noHostSettingSideEffect,
     [SETTING_SIDE_EFFECT.MEDIA_DUCK]: noHostSettingSideEffect,
-    [SETTING_SIDE_EFFECT.VOICE]: ({ settings }) => dependencies.setVoice(settings.voice),
-    [SETTING_SIDE_EFFECT.VOICE_SOURCE]: async () => {
-      await dependencies.applyVoiceCredential();
-      await dependencies.emitSettings();
-    },
-    [SETTING_SIDE_EFFECT.ANNOUNCEMENT_HOLD]: () => dependencies.reconcileSpeech(),
+    [SETTING_SIDE_EFFECT.VOICE]: ({ settings }) =>
+      Effect.sync(() => {
+        dependencies.setVoice(settings.voice);
+      }),
+    // The credential is still a promise, so a rejection is the defect the
+    // settings write's own refusal reads it as, exactly as an awaited one was.
+    [SETTING_SIDE_EFFECT.VOICE_SOURCE]: () =>
+      Effect.zipRight(
+        Effect.promise(() => dependencies.applyVoiceCredential()),
+        dependencies.emitSettings(),
+      ),
+    [SETTING_SIDE_EFFECT.ANNOUNCEMENT_HOLD]: () =>
+      Effect.sync(() => {
+        dependencies.reconcileSpeech();
+      }),
     [SETTING_SIDE_EFFECT.VAULT_SYNC]: ({ settings }) =>
       dependencies.applyVaultSync(settings.syncProviderKeys),
   } satisfies HostSettingSideEffects;


### PR DESCRIPTION
P12-14h

The settings composer's two promise chains become Effect `Queue`s, each drained
by a fiber of the composer's own lifetime scope.

- **The account-preferences chain.** `queueAccountPreferencesSync(label, work)`
  offers an `Effect` onto an unbounded queue; one fiber takes them one at a time
  and runs each, so a reconcile and a push cannot interleave into a snapshot
  that agrees with neither — exactly the serialization the `.then(work, work)`
  chain held. A failure is still reported as
  `Account preferences <label> failed: <message>`, read off the `Cause` the same
  way the `catch` read the rejection, with a defect included; only an
  interruption stands, so the scope's close ends the fiber rather than
  reporting a line.
- **The vault chain.** `ProviderKeyVaultSync` is `providerKeyVaultSync(options)`,
  an `Effect`-built collaborator holding a queue of actions and the `actions`
  effect that drains it. `keySaved` and `apply` offer; the sweep's re-read of
  whose account stands, the tenant-record rules, and the quiet-on-failure
  behavior are unchanged, and the only thing still promise-shaped inside is
  `HostedVaultClient`, whose own run shim stands on its own row.
- **The store, not its awaited face.** Every read and write either chain makes
  is `SettingsStore`'s own effect. `readAccountPreferenceAccountKey`,
  `accountPreferenceHydrationBaseline`, `hydrateAccountPreferences`, and
  `applyAccountPreferenceSideEffects` are effects.
- **`AccountPreferencesClient` answers effects**, over `accountCall` rather than
  the deprecated `createAccountCall` promise door, with the `HttpClient` layer it
  is handed (or `FetchHttpClient.layer`) provided inside — so it runs nothing.
- **The host setting side-effect table answers effects.** `applyVaultSync` and
  `emitSettings` are effects; `applyVoiceCredential` is still a promise, wrapped
  in `Effect.promise` so a rejection stays the defect `settingsWrite`'s refusal
  already read it as.
- **Entry points.** `compose-host.ts` yields `reconcileAccountPreferences`,
  `emitSettings`, and `reconcileProviderKeyVault` in the same program order.
  `compose-observation.ts:276` is untouched: `pushAccountPreferences` stays an
  offer, because that caller is a promise body with no fiber to yield on.
  `compose-account.ts`'s synchronous `onChange` forks `settings.emitSettings()`
  onto the runtime the composer already captures.

### What this row did not do, and why

The plan tables (h) as the last slice, deleting `settings-store-awaited.ts`,
`SettingsComposer.awaitedStore`, the ADR paragraph and table row, and the
`effect-edges.json` entry, and converting `settings-store.test.ts`. It is not
last. P12-14g (#1275) landed while this was open; P12-14f (#1274) is still open,
and even with it landed the face still has callers —
`session-action-performer.ts:85`, `compose-account.ts`'s session-replay account
read, and the one setting each of the two calendar readers takes as a promise
option. Deleting the shim here would not compile. This PR therefore lands the
conversion the row names — the two chains as fibers, the settings composer off
the awaited face entirely — and leaves the deletion to whichever slice is
genuinely last.

The ADR is amended accordingly: the shim's paragraph and table row now read
P12-14i, and neither names the settings composer's chains any more.

**The remaining slice, for a new workspace — P12-14i:**
`session-action-performer.ts` and its test, `compose-account.ts`'s
session-replay account read, the two calendar readers' promise options, and then
the deletion: `settings-store-awaited.ts`, `SettingsComposer.awaitedStore`, the
ADR paragraph and table row, the `effect-edges.json` `runOnHandedRuntime` entry,
and `settings-store.test.ts`'s 71 tests converted (`storeIn` at ~156 returns
`AwaitedSettingsStore`; the helpers at 202-219; the two `it.effect` tests at the
file's end are the pattern).

### One new run, written down

`compose-account.ts` gains a single `Runtime.runFork(runtime)(settings.emitSettings())`
in the session manager's synchronous `onChange`, on the runtime the composer
already captures rather than one built there. The file is already on
`effect-edges.json`'s `runOnHandedRuntime` list (P12-14g put it back for
`applyVoiceCredential`), so the JSON is unchanged; the ADR gains the paragraph
and the shim table row naming this run's own deletion, once `onChange` itself
answers an effect.

### Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` exits 0 locally. `verify.sh` is macOS-only and this cloud workspace is Linux; the PR touches no renderer, no UI, and no drawing, so there is no visual evidence to inspect.
- [x] JSON Schema goldens unchanged. — `LUKE_UPDATE_FIXTURES` not run; no schema touched.
- [x] Gateway envelope goldens unchanged. — the gateway golden suite passes unchanged; the four settings handlers keep their refusal wording and `settingsWrite` shape.
- [x] No new `as` type assertion outside the allowlisted files. — none added; the two `SAFETY:` casts in the settings handlers are unchanged.
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — one new `Runtime.runFork` in `compose-account.ts`, on the handed runtime, added to `effect-edges.json`'s `runOnHandedRuntime` with its ADR paragraph and table row naming its deletion. Not "N/A": it is the sanctioned face for a synchronous callback with no fiber. Two runs were removed with `createAccountCall`'s door leaving `AccountPreferencesClient`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package. — one `Promise.resolve()` and one promise chain were deleted; none added.
- [x] Test count equals the pre-PR count or the delta is listed. — unchanged. `account-preferences-client.test.ts`'s five tests moved from `test` to `it.effect` in place, asserting the same values.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `ProviderKeyVaultSync`'s promise chain and the settings composer's `accountPreferencesSync` chain are deleted outright. `awaitedSettingsStore` keeps its `@deprecated` tag; its deletion PR is renumbered P12-14f..i in the doc comment's terms via the ADR, and its remaining callers are named there.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair byte-identical. — no sentence in any pair names these parts; `packages/host/CLAUDE.md`'s `account-preferences-client.ts` sentence is about where the file lives, which is unchanged. Root pair untouched and byte-identical.
- [x] `PRIVACY.md` unchanged. — untouched.
- [x] Package `package.json` deps match bare-specifier imports; `effect` via `catalog:`. — `@effect/platform` and `effect` were already `@sidecar/host` dependencies, both `catalog:`; no new third-party dependency, so nothing `apps/web` reaches changed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — no `@effect/platform-node` or `@effect/sql*` import added; `@effect/platform/FetchHttpClient` is the same web-safe module the vault client already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
