### PR TITLE
chore(desktop): tighten the renderer bundle budget slack to five percent

### DIFF
--- a/apps/desktop/bundle-budget.json
+++ b/apps/desktop/bundle-budget.json
@@ -1,7 +1,7 @@
 {
-  "slack": 0.15,
+  "slack": 0.05,
   "gzipBytes": {
-    "renderer/renderer.js": 639579,
-    "renderer/voice.js": 321864
+    "renderer/renderer.js": 635847,
+    "renderer/voice.js": 323364
   }
 }


### PR DESCRIPTION
P12-12

Tightens the renderer bundle budget's slack from 15% to 5% and re-records both baselines from a from-scratch build of current `main`.

- `apps/desktop/bundle-budget.json`: `renderer.js` re-recorded at 635,847 gzipped bytes (down from 639,579), `voice.js` at 323,364 (up from 321,864) — both within the old 15% slack, so this is accumulated drift since P9-08, not a library adoption. `slack` set to `0.05`.
- Confirmed via the emitted source maps that each bundle resolves exactly one `node_modules/effect` tree and neither reaches `@effect/platform-node` nor `@effect/sql`.
- The ADR's renderer-cost section is not updated in this PR: P12-11 deletes the ADR, so the rule that a baseline moves only for a deliberate library adoption named in its own PR, never for drift, is recorded here in the PR body instead.

No source change; scope is exactly the plan row (bundle-budget.json only).

## Invariants checklist

- [x] `./scripts/check.sh` green (includes the desktop build against the tightened 5% budget). (CI)
- [ ] `./scripts/verify.sh` — not run; this cloud workspace is Linux, and verify.sh is macOS-only. No UI/source change was made, only the budget config, so nothing here needs visual evidence.
- [x] JSON Schema goldens unchanged (no fixtures touched).
- [x] Gateway envelope goldens unchanged (no gateway code touched).
- [x] No new `as` assertion outside allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (no OpenClaw files touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside runtime edges (no code touched).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` (no code touched).
- [x] Test count unchanged (881 passed — no tests added/removed).
- [x] No hand-rolled file replaced or deprecated by this PR (n/a — config only).
- [x] `CLAUDE.md`/`AGENTS.md` sentences: checked for any naming the bundle budget's 15%/slack value; none found, so no doc edits needed.
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps unchanged; no new dependency added.
- [x] Barrel/door rule: verified via source map inspection — one `effect` copy, no `@effect/platform-node`/`@effect/sql` reachable from either renderer bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)