### PR TITLE
refactor(runtime): the tool executor seam and the brain's tools answer effects

### DIFF
--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -364,25 +364,23 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
           apiKey: (providerId) => seams.providerKey(userId, providerId),
           execute: seams.executeAction,
         });
-        return yield* Effect.promise(() =>
-          runHostedTool(
-            name,
-            input,
-            context,
-            {
-              conversation: binding.target,
-              roster,
-              carrier,
-              transcripts,
-              workspace: hostedWorkspaceAccess(run, seams.store(), userId, seams.now),
-              now: seams.now,
-            },
-            {
-              trigger: binding.turn.trigger,
-              turnId: binding.turn.turnId,
-              runId: binding.turn.turnId,
-            },
-          ),
+        return yield* runHostedTool(
+          name,
+          input,
+          context,
+          {
+            conversation: binding.target,
+            roster,
+            carrier,
+            transcripts,
+            workspace: hostedWorkspaceAccess(run, seams.store(), userId, seams.now),
+            now: seams.now,
+          },
+          {
+            trigger: binding.turn.trigger,
+            turnId: binding.turn.turnId,
+            runId: binding.turn.turnId,
+          },
         );
       }),
 

--- a/apps/web/server/hosted/brain-host/tools.ts
+++ b/apps/web/server/hosted/brain-host/tools.ts
@@ -1,4 +1,5 @@
 import { emitJsonSchema } from "@sidecar/wire/effect";
+import { Effect } from "effect";
 import type { ToolContext as EveToolContext, ToolDefinition } from "eve/tools";
 import { NOTEBOOK_MEMORY_TOOL } from "../../../../../packages/memory/src/index.js";
 import {
@@ -125,7 +126,7 @@ function fieldsOf(input: UnparsedWireValue): WireRecord | undefined {
   return isRecord(input) ? input : undefined;
 }
 
-type ModuleRun = (fields: WireRecord, standing: ToolContext) => Promise<WireRecord>;
+type ModuleRun = (fields: WireRecord, standing: ToolContext) => Effect.Effect<WireRecord>;
 
 /**
  * One tool as eve is told of it: the module's own name, words, and wire
@@ -188,21 +189,25 @@ function runOf(
 ): ModuleRun {
   switch (named.kind) {
     case "action":
-      return async (fields, standing) =>
-        named.module.execute(fields, {
-          ...standing,
-          admission: await seams.carrier.admission(),
-          carry: (action) => seams.carrier.carry(action, fields, standing),
+      return (fields, standing) =>
+        Effect.gen(function* () {
+          const admission = yield* Effect.promise(() => seams.carrier.admission());
+          return yield* named.module.execute(fields, {
+            ...standing,
+            admission,
+            carry: (action) => seams.carrier.carry(action, fields, standing),
+          });
         });
     case "read":
-      return async (fields, standing) => {
-        const roster = brainRosterOf(await seams.roster(), seams.now());
-        return named.module.execute(fields, {
-          ...standing,
-          roster: { text: roster.text, identities: roster.identities },
-          readTranscript: (identity) => seams.transcripts.whole(identity),
+      return (fields, standing) =>
+        Effect.gen(function* () {
+          const roster = brainRosterOf(yield* Effect.promise(() => seams.roster()), seams.now());
+          return yield* named.module.execute(fields, {
+            ...standing,
+            roster: { text: roster.text, identities: roster.identities },
+            readTranscript: (identity) => Effect.promise(() => seams.transcripts.whole(identity)),
+          });
         });
-      };
     case "announce":
       // The words become the call's own part on the journal, and the relay
       // puts them on offer when it records the call as settled; the tool
@@ -210,11 +215,13 @@ function runOf(
       return (fields, standing) =>
         named.module.execute(fields, { ...standing, announce: () => undefined });
     case "workspace":
+      // Nothing here journals: the service's own record of the call is the
+      // turn record eve keeps, so the effect runs as the module handed it.
       return (fields, standing) =>
         named.module.execute(fields, {
           ...standing,
           workspace: seams.workspace,
-          journal: (effect) => effect(),
+          journal: (effect) => effect,
         });
   }
 }
@@ -226,19 +233,23 @@ function runOf(
  * refused here again, so the set the model was offered and the gate a call
  * meets are one resolution.
  */
-export async function runHostedTool(
+export function runHostedTool(
   name: string,
   input: UnparsedWireValue,
   context: EveToolContext,
   seams: HostedToolSeams,
   turn: HostedTurnStanding,
-): Promise<WireRecord> {
-  if (!hostedTurnPolicy(turn.trigger).allows(name)) return NO_SUCH_TOOL;
-  const named = moduleNamed(name);
-  if (!named) return NO_SUCH_TOOL;
-  const fields = fieldsOf(input);
-  if (fields === undefined) return UNREADABLE_CALL;
-  const standing = standingOf(context, seams, turn);
-  if (standing.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER);
-  return runOf(named, seams)(fields, standing);
+): Effect.Effect<WireRecord> {
+  return Effect.suspend(() => {
+    if (!hostedTurnPolicy(turn.trigger).allows(name)) return Effect.succeed(NO_SUCH_TOOL);
+    const named = moduleNamed(name);
+    if (!named) return Effect.succeed(NO_SUCH_TOOL);
+    const fields = fieldsOf(input);
+    if (fields === undefined) return Effect.succeed(UNREADABLE_CALL);
+    const standing = standingOf(context, seams, turn);
+    if (standing.isRevoked()) {
+      return Effect.succeed(refusedActionOutput(ACTION_REFUSAL.TURN_OVER));
+    }
+    return runOf(named, seams)(fields, standing);
+  });
 }

--- a/apps/web/tests/hosted-brain-host-tools.test.ts
+++ b/apps/web/tests/hosted-brain-host-tools.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { Effect } from "effect";
 import type { ToolContext as EveToolContext } from "eve/tools";
 import { afterAll, test } from "vitest";
 import {
@@ -164,7 +165,7 @@ function call(
     hostedToolDeclarations(turn.trigger).some((declared) => declared.name === name),
     `${name} is offered`,
   );
-  return runHostedTool(name, input, context, seams, turn);
+  return Effect.runPromise(runHostedTool(name, input, context, seams, turn));
 }
 
 test("an ask is offered the catalog under the hosted policy, an observation the same set plus announce", () => {
@@ -249,12 +250,8 @@ test("announce answers accepted for words and refuses an empty briefing; it is o
   assert.equal(offered.status, ACTION_RESULT_STATUS.ACCEPTED);
   const empty = await call(seams, OBSERVATION, BRAIN_TOOL.ANNOUNCE, { briefing: "" });
   assert.equal(empty.status, ACTION_RESULT_STATUS.REJECTED);
-  const withheld = await runHostedTool(
-    BRAIN_TOOL.ANNOUNCE,
-    { briefing: "x" },
-    eveContext(),
-    seams,
-    ASK,
+  const withheld = await Effect.runPromise(
+    runHostedTool(BRAIN_TOOL.ANNOUNCE, { briefing: "x" }, eveContext(), seams, ASK),
   );
   assert.equal(withheld.status, ACTION_RESULT_STATUS.REJECTED);
 });

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -265,12 +265,15 @@ the queued pass behind it as a daemon, which is exactly what the detached
 `composeObservation` in `packages/host/src/compose-observation.ts` is on the
 handed-runtime list: `settleHostedWrite` pokes a redraw after every landed
 session write, and both its callers — the session action performer the brain
-carries an admitted act through, and a row's own press — settle inside the
-`ToolExecutor` seam's promise rather than in a fiber. So the composer reads
+carries an admitted act through, and a row's own press — settle inside
+`SessionActionPerformer.perform`'s own promise rather than in a fiber. So the
+composer reads
 `Effect.runtime<never>()` out of its own build and hands those two a
 `pokeRefresh` that is `Runtime.runFork` of `loop.refresh` on it; it forks onto
 the runtime it was handed and never builds one, and `settleHostedWrite` itself
-runs nothing. It goes when that seam answers an effect.
+runs nothing. It goes when that performer and the carrier above it answer
+effects; the `ToolExecutor` seam between them stopped being the blocker in
+P12-15c.
 
 `composeBrain` in `packages/host/src/compose-brain.ts` is on the same list
 for the other half of the same seam: the roster and projects reads
@@ -292,13 +295,13 @@ goes when that link answers an effect.
 `admitEffect()`, an Effect failing with an `AdmitRefusal`, and `admit()` runs it
 to the `Promise<ValidatedAction | Refusal>` its callers still hold, answering
 the refusal as the `Refusal` the action journal records and rethrowing a roster
-read's own failure. Its callers reach it across the `ToolExecutor` seam and
-the web's action endpoint, neither of which answers an effect yet — a turn is
-a fiber from P12-02 on, but the tool call it dispatches still crosses a
-promise. P12-04 turned out to be the CloudFetch/HttpClient family alone; this
-door waits on the `ToolExecutor` seam in `@sidecar/runtime/vocabulary`
-answering an effect, a change to the tool-dispatch shape rather than a
-transport, so it is re-pointed at P12-15 instead.
+read's own failure. The brain's action tools left it in P12-15c and admit the
+call as an effect, since the `ToolExecutor` seam they run under answers one;
+what still holds the door is the web's action endpoint, which is a promise
+from `executeSessionAction` up, and the two testing doors over it
+(`@sidecar/actions`'s `tool-call.ts` and the provider contract's oracle).
+P12-04 turned out to be the CloudFetch/HttpClient family alone, so the door
+waits on those three answering effects instead.
 
 `BrainTransport#send`'s internal `runCall` in `packages/brain/src/client.ts`
 is the fifth: every caller of the brain's model transport still holds a
@@ -923,25 +926,40 @@ whose value must be owned by exactly one party.
 
 What keeps this one door is what the brain is still asked for in promises:
 `BrainAgent`'s own public surface — an ask, a wake, a child's task, a stop —
-and the `ToolExecutor` seam the tool loop dispatches through, which is why
-the read tool's whole-transcript read and the housekeeping turn the memory
-provider's `capture` seam asks for are carried here too. A defect is squashed
-back to the error that caused it, so a store, a listener, or an engine that
-threw reaches the caller as the error it threw rather than as the fiber
-failure that carried it. P12-04 deletes it with those seams.
+and the housekeeping turn the memory provider's `capture` seam asks for. The
+`ToolExecutor` seam left that list in P12-15c and the read tool's
+whole-transcript read went with it into the tool loop's own fiber; what
+carries a read here now is the prefetch, whose slots are a promise memo until
+P12-02's own row moves them. A defect is squashed back to the error that
+caused it, so a store, a listener, or an engine that threw reaches the caller
+as the error it threw rather than as the fiber failure that carried it.
+P12-04 deletes it with those seams.
 
-What the door does not carry is the other three seams. `ModelAdapter`,
-`ContextEngine`, and `ToolExecutor` stay as the host hands them in, because
-each is owned above the runtime by identity rather than by shape: the host
-marks, rolls back, and checkpoints the very engine `openContext` answered and
-compares it by reference, and it folds the context through the same adapter
-inside `compaction.ts`, which is an OpenClaw port and so imports nothing from
-`effect`. An Effect-shaped counterpart for any of the three would therefore
-need a promise view built back out of it inside the brain, which is the same
-run in another file rather than one less — so `ModelAdapter` stays
-Promise-shaped permanently, like the other two, and the two shims that stand
-on it — `BrainTransport#send`'s `runCall` and `tracedModelAdapter`'s traced
-`respond` — are permanent rows for the same reason, named below.
+What the door does not carry is the other two seams. `ModelAdapter` and
+`ContextEngine` stay as the host hands them in, because each is owned above
+the runtime by identity rather than by shape: the host marks, rolls back, and
+checkpoints the very engine `openContext` answered and compares it by
+reference, and it folds the context through the same adapter inside
+`compaction.ts`, which is an OpenClaw port and so imports nothing from
+`effect`. An Effect-shaped counterpart for either would therefore need a
+promise view built back out of it inside the brain, which is the same run in
+another file rather than one less — so `ModelAdapter` stays Promise-shaped
+permanently, like `ContextEngine`, and the two shims that stand on it —
+`BrainTransport#send`'s `runCall` and `tracedModelAdapter`'s traced `respond`
+— are permanent rows for the same reason, named below.
+
+`ToolExecutor` was on that list until P12-15c and is not owned that way: the
+brain builds the executor a turn hands its runtime, and no port consumes one,
+so `execute` answers an `Effect<ToolResult>` and the loop dispatches a call
+on its own fiber rather than across `Effect.tryPromise`. Every tool of the
+brain answers an effect with it — the action modules, the reads, the
+briefing, delegation, the workspace writes — so the journal that records a
+call before it runs and settles it after is one effect around another, and
+the batch the runtime already held uninterruptible is still what keeps a
+dispatched effect from being parted from its result. What stays a promise
+inside the executor is what the host hands it: the turn's checkpoint, the
+whole-transcript read, the child and workspace access, the memory provider's
+own tools, and the carrier an admitted action reaches.
 
 The rest of this package's Promise faces turned out to stand on
 `BrainAgent`'s own public surface rather than on the vocabulary's: a wake, an
@@ -1144,12 +1162,12 @@ design decision stated as such:
 | TaggedErrors carry legacy `code` strings on wire | P3-04 onward | never — the wire is the compatibility surface |
 | `cloudFetchFromHttpClient` | P1-07 | P12-04e |
 | `timersFromRuntime` | P2-01 | P12-03 |
-| `admit()` Promise door over `admitEffect()` | P4-01 | P12-15 — blocked on the `ToolExecutor` seam answering an effect; P12-04 turned out to be the CloudFetch/HttpClient family alone |
+| `admit()` Promise door over `admitEffect()` | P4-01 | pending — the brain's action tools stopped using it in P12-15c; blocked now on the web's `executeSessionAction` and the two testing doors over it answering effects |
 | `BrainTransport#send`'s internal `runCall`, over `runtimeExit(execution)` since P12-04d | P5-05 | never — permanent alongside `tracedModelAdapter`, `compaction.ts`'s `ModelAdapter` stays a promise |
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04b |
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04b |
 | `@sidecar/host`'s `compose-devices.ts`, over the change-signal client above (`snapshot-roster.ts` and `compose-conversation.ts`'s `runClientEffect` were on this row and P12-15a deleted both) | P12-04b | pending — once `deviceCadence`'s beat is a fiber |
-| `composeObservation`'s `pokeRefresh`, the redraw a landed session write earns, forked on the runtime the composer was built on | P12-15a | with the `ToolExecutor` seam answering an effect |
+| `composeObservation`'s `pokeRefresh`, the redraw a landed session write earns, forked on the runtime the composer was built on | P12-15a | with `SessionActionPerformer.perform` and the carrier above it answering effects |
 | `composeBrain`'s `refreshSessions`, the admission pass run to a promise on the host's own runtime | P12-15a | with `admit()`'s Promise door |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-05 |

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -615,9 +615,7 @@ class ScriptedRuntime implements AgentRuntimeEffect {
           isRevoked: () => request.signal.aborted,
         };
         contexts.push(context);
-        const result = yield* Effect.promise(
-          async () => await request.tools.execute(invocation, context),
-        );
+        const result = yield* request.tools.execute(invocation, context);
         yield* Effect.promise(
           async () =>
             await request.context.ingest({

--- a/packages/brain/src/effect/carry.ts
+++ b/packages/brain/src/effect/carry.ts
@@ -1,11 +1,12 @@
 /**
  * The brain's one door onto the host's `ExecutionRuntime`. A turn, the
- * maintenance behind it, and the housekeeping run are each a fiber end to
- * end; what is still a promise is the surface `BrainAgent` answers a host on
- * — an ask, a wake, a child's task — and the `ToolExecutor` seam the tool
- * loop dispatches through. Both of those are promises because the seams
- * above and below them are, so the carrying happens once, here, rather than
- * in each file that holds one.
+ * maintenance behind it, the tool loop, and the housekeeping run are each a
+ * fiber end to end; what is still a promise is the surface `BrainAgent`
+ * answers a host on — an ask, a wake, a child's task — and the read
+ * prefetch's own slots, whose memo is a promise until the reads it holds are
+ * a fiber's. Both of those are promises because the seams above and below
+ * them are, so the carrying happens once, here, rather than in each file
+ * that holds one.
  *
  * A defect is squashed back to the error that caused it, so a store, a
  * listener, or an engine that threw reaches the caller as the error it threw
@@ -13,7 +14,7 @@
  *
  * @deprecated The strangler shim on the `Effect.runPromise` allowlist in
  * `docs/adr/0001-effect.md`; P12-04 deletes it with the seams that keep it,
- * once `BrainAgent`'s own surface and the `ToolExecutor` answer effects.
+ * once `BrainAgent`'s own surface answers effects.
  */
 import type { ExecutionRuntime } from "@sidecar/runtime/vocabulary";
 import { Cause, type Effect, Exit, ManagedRuntime, Runtime } from "effect";

--- a/packages/brain/src/housekeeping.ts
+++ b/packages/brain/src/housekeeping.ts
@@ -125,40 +125,41 @@ export function runMemoryHousekeeping(
     .map((tool) => tool.schema);
   let writes = 0;
   const tools: ToolExecutor = {
-    execute: async (call, context) => {
-      if (!HOUSEKEEPING_TOOLS.has(call.name)) return rejection(REFUSAL_REASON.NOT_OFFERED);
-      if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-      let args: WireRecord = {};
-      try {
-        args = wireRecord(JSON.parse(call.argumentsJson)) ?? {};
-      } catch {
-        args = {};
-      }
-      const name = isWireString(args.name) ? args.name : "";
-      if (call.name === BRAIN_TOOL.READ_WORKSPACE_FILE) {
-        const read = await options.workspace.read(name);
-        return read.ok
-          ? answer({ status: ACTION_RESULT_STATUS.ACCEPTED, name, content: read.content })
-          : rejection(read.reason);
-      }
-      if (!isDailyNotePathForDay(name, options.dateStamp)) {
-        return rejection(HOUSEKEEPING_REFUSAL.NOT_TODAYS_NOTE);
-      }
-      const content = isWireString(args.content) ? args.content : "";
-      const existing = await options.workspace.read(name);
-      if (!existing.ok && existing.reason !== WORKSPACE_FILE_REFUSAL.NOT_FOUND) {
-        return rejection(existing.reason);
-      }
-      const previous = existing.ok ? existing.content : "";
-      if (!isAppendOnlyRewrite(previous, content)) {
-        return rejection(HOUSEKEEPING_REFUSAL.NOT_APPEND_ONLY);
-      }
-      if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-      const written = await options.workspace.write(name, content);
-      if (!written.ok) return rejection(written.reason);
-      writes += 1;
-      return answer({ status: ACTION_RESULT_STATUS.ACCEPTED, name, chars: written.chars });
-    },
+    execute: (call, context) =>
+      Effect.gen(function* () {
+        if (!HOUSEKEEPING_TOOLS.has(call.name)) return rejection(REFUSAL_REASON.NOT_OFFERED);
+        if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
+        let args: WireRecord = {};
+        try {
+          args = wireRecord(JSON.parse(call.argumentsJson)) ?? {};
+        } catch {
+          args = {};
+        }
+        const name = isWireString(args.name) ? args.name : "";
+        if (call.name === BRAIN_TOOL.READ_WORKSPACE_FILE) {
+          const read = yield* Effect.promise(() => options.workspace.read(name));
+          return read.ok
+            ? answer({ status: ACTION_RESULT_STATUS.ACCEPTED, name, content: read.content })
+            : rejection(read.reason);
+        }
+        if (!isDailyNotePathForDay(name, options.dateStamp)) {
+          return rejection(HOUSEKEEPING_REFUSAL.NOT_TODAYS_NOTE);
+        }
+        const content = isWireString(args.content) ? args.content : "";
+        const existing = yield* Effect.promise(() => options.workspace.read(name));
+        if (!existing.ok && existing.reason !== WORKSPACE_FILE_REFUSAL.NOT_FOUND) {
+          return rejection(existing.reason);
+        }
+        const previous = existing.ok ? existing.content : "";
+        if (!isAppendOnlyRewrite(previous, content)) {
+          return rejection(HOUSEKEEPING_REFUSAL.NOT_APPEND_ONLY);
+        }
+        if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
+        const written = yield* Effect.promise(() => options.workspace.write(name, content));
+        if (!written.ok) return rejection(written.reason);
+        writes += 1;
+        return answer({ status: ACTION_RESULT_STATUS.ACCEPTED, name, chars: written.chars });
+      }),
   };
   return Effect.catchAllDefect(
     Effect.map(

--- a/packages/brain/src/read-prefetch.ts
+++ b/packages/brain/src/read-prefetch.ts
@@ -553,12 +553,15 @@ export class ReadPrefetch implements TurnReadPrefetch {
       isRevoked: () => signal.aborted,
       signal,
       roster: { text: roster.text, identities: roster.identities },
-      readTranscript: (identity) => this.#options.readTranscript(identity, signal),
+      readTranscript: (identity) =>
+        Effect.promise(() => this.#options.readTranscript(identity, signal)),
     };
     if (read.kind === PREFETCH_READ_KIND.TRANSCRIPT) {
       const module = readToolNamed(BRAIN_TOOL.READ_TRANSCRIPT);
       if (!module) return Promise.resolve(rejection(REFUSAL_REASON.NOT_OFFERED));
-      return module.execute(args, standing);
+      // The module answers an effect; this slot's memo is a promise, so the
+      // read is carried onto the host's runtime through the brain's one door.
+      return this.#options.carry(module.execute(args, standing));
     }
     const memory = this.#options.memory;
     const tool = memory ? memoryToolNamed(memory.provider, read.kind) : undefined;

--- a/packages/brain/src/runtime.test.ts
+++ b/packages/brain/src/runtime.test.ts
@@ -172,10 +172,11 @@ function harness(tools?: Partial<ToolExecutor>): Harness {
   context.bootstrap(undefined, UNKNOWN_ACTION_RESULT);
   const abort = new AbortController();
   const executor: ToolExecutor = {
-    execute: async (invocation) => {
-      executed.push(invocation);
-      return { outputJson: JSON.stringify({ status: "accepted", call: invocation.callId }) };
-    },
+    execute: (invocation) =>
+      Effect.sync(() => {
+        executed.push(invocation);
+        return { outputJson: JSON.stringify({ status: "accepted", call: invocation.callId }) };
+      }),
     ...tools,
   };
   return {
@@ -350,12 +351,13 @@ test("a cancel between two calls still reaches the executor for the second, whic
   const h = harness();
   let run: RuntimeRun | undefined;
   const executor: ToolExecutor = {
-    execute: async (invocation, context) => {
-      h.executed.push(invocation);
-      const status = context.isRevoked() ? "rejected" : "accepted";
-      if (invocation.callId === "c1") run?.cancel();
-      return { outputJson: JSON.stringify({ status }) };
-    },
+    execute: (invocation, context) =>
+      Effect.sync(() => {
+        h.executed.push(invocation);
+        const status = context.isRevoked() ? "rejected" : "accepted";
+        if (invocation.callId === "c1") run?.cancel();
+        return { outputJson: JSON.stringify({ status }) };
+      }),
   };
   h.model.answers.push(
     answered({
@@ -394,10 +396,11 @@ test("steered words are read at the next safe boundary: after the tool that was 
   const h = harness();
   let run: RuntimeRun | undefined;
   const steering: ToolExecutor = {
-    execute: async (invocation) => {
-      assert.equal(run?.steer({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text: "also this" }), true);
-      return { outputJson: JSON.stringify({ status: "accepted", call: invocation.callId }) };
-    },
+    execute: (invocation) =>
+      Effect.sync(() => {
+        assert.equal(run?.steer({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text: "also this" }), true);
+        return { outputJson: JSON.stringify({ status: "accepted", call: invocation.callId }) };
+      }),
   };
   h.model.answers.push(
     answered({
@@ -426,9 +429,10 @@ test("steered words are read at the next safe boundary: after the tool that was 
 
 test("an executor that throws leaves an unknown answer paired to the call rather than a dangling call", async () => {
   const h = harness({
-    execute: async () => {
-      throw new Error("boom");
-    },
+    execute: () =>
+      Effect.sync(() => {
+        throw new Error("boom");
+      }),
   });
   h.model.answers.push(
     answered({
@@ -462,7 +466,7 @@ test("with the guard enabled, a critical verdict pairs every remaining call and 
     });
   for (let index = 0; index < 40; index += 1) h.model.answers.push(repeated());
   const executor: ToolExecutor = {
-    execute: async () => ({ outputJson: '{"status":"running"}' }),
+    execute: () => Effect.succeed({ outputJson: '{"status":"running"}' }),
   };
   const end = await runtime(h.model, { enabled: true }).start(h.request({ tools: executor })).done;
   assert.equal(end.reason, RUN_END_REASON.LOOP_GUARD);
@@ -505,10 +509,11 @@ test("every context handed to an executor is revoked once the run ends, on compl
   const completed = harness();
   const contexts: ToolExecutionContext[] = [];
   const capturing: ToolExecutor = {
-    execute: async (invocation, context) => {
-      contexts.push(context);
-      return { outputJson: JSON.stringify({ status: "accepted", call: invocation.callId }) };
-    },
+    execute: (invocation, context) =>
+      Effect.sync(() => {
+        contexts.push(context);
+        return { outputJson: JSON.stringify({ status: "accepted", call: invocation.callId }) };
+      }),
   };
   const oneCall = () =>
     answered({
@@ -662,11 +667,12 @@ test("a cancel inside a batch parts no call from the result its host records, an
   let run: RuntimeRun | undefined;
   const recorded: string[] = [];
   const executor: ToolExecutor = {
-    execute: async (invocation) => {
-      h.executed.push(invocation);
-      if (invocation.callId === "c1") run?.cancel();
-      return { outputJson: JSON.stringify({ status: "accepted" }) };
-    },
+    execute: (invocation) =>
+      Effect.sync(() => {
+        h.executed.push(invocation);
+        if (invocation.callId === "c1") run?.cancel();
+        return { outputJson: JSON.stringify({ status: "accepted" }) };
+      }),
   };
   h.model.answers.push(
     answered({

--- a/packages/brain/src/runtime.ts
+++ b/packages/brain/src/runtime.ts
@@ -468,7 +468,10 @@ function absorb(
   });
 }
 
-/** One call, handed to the executor; a tool that threw instead of answering is told as unknown rather than left dangling. */
+/**
+ * One call, handed to the executor on the loop's own fiber; a tool that died
+ * instead of answering is told as unknown rather than left dangling.
+ */
 function executeToolCall(
   call: ToolInvocation,
   tools: RuntimeRunRequestEffect["tools"],
@@ -477,14 +480,13 @@ function executeToolCall(
   revoked: () => boolean,
 ): Effect.Effect<ToolResult> {
   return Effect.gen(function* () {
-    const result = yield* Effect.merge(
-      Effect.tryPromise({
-        try: async () => await tools.execute(call, { runId, signal, isRevoked: revoked }),
-        catch: (): ToolResult => ({
+    const result = yield* Effect.catchAllDefect(
+      tools.execute(call, { runId, signal, isRevoked: revoked }),
+      (): Effect.Effect<ToolResult> =>
+        Effect.succeed({
           outputJson: JSON.stringify(TOOL_DID_NOT_ANSWER),
           status: TOOL_DID_NOT_ANSWER.status,
         }),
-      }),
     );
     const status = result.status ?? outputStatus(result.outputJson);
     return status !== undefined ? { outputJson: result.outputJson, status } : result;

--- a/packages/brain/src/testing.ts
+++ b/packages/brain/src/testing.ts
@@ -18,6 +18,7 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import type { Session } from "@sidecar/session";
 import type { WireRecord } from "@sidecar/wire";
+import { Effect } from "effect";
 import type { BrainPersistedState, BrainStateLoad, BrainStateRepository } from "./envelope.js";
 import { BRAIN_MAXIMUM_OUTPUT_TOKENS, failed } from "./model-adapter-shared.js";
 import type { BrainActionExecution, BrainActionPerformer } from "./performer.js";
@@ -245,18 +246,20 @@ export function fakeActionPerformer(options: FakeActionPerformerOptions = {}): F
  * over the performer's two halves. A name no module answers, or arguments
  * that are not a record, refuse before anything is admitted.
  */
-export async function performCall(
+export function performCall(
   actions: BrainActionPerformer,
   call: ActionFunctionCall,
   execution: BrainActionExecution,
-): Promise<ActionOutputEnvelope> {
-  const tool = actionToolNamed(call.name);
-  if (!tool) return refusedActionOutput(ACTION_REFUSAL.NO_TOOL);
-  const input = toolArguments(call.argumentsJson);
-  if (input === undefined) return refusedActionOutput(ACTION_REFUSAL.UNREADABLE);
-  return tool.execute(input, {
-    ...execution,
-    admission: actions.admission(execution),
-    carry: (action) => actions.carry(action, execution),
+): Effect.Effect<ActionOutputEnvelope> {
+  return Effect.suspend(() => {
+    const tool = actionToolNamed(call.name);
+    if (!tool) return Effect.succeed(refusedActionOutput(ACTION_REFUSAL.NO_TOOL));
+    const input = toolArguments(call.argumentsJson);
+    if (input === undefined) return Effect.succeed(refusedActionOutput(ACTION_REFUSAL.UNREADABLE));
+    return tool.execute(input, {
+      ...execution,
+      admission: actions.admission(execution),
+      carry: (action) => actions.carry(action, execution),
+    });
   });
 }

--- a/packages/brain/src/tool-executor.test.ts
+++ b/packages/brain/src/tool-executor.test.ts
@@ -25,7 +25,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import { Schema as EffectSchema } from "effect";
+import { Effect, Schema as EffectSchema } from "effect";
 import { test } from "vitest";
 import { BrainJournal } from "./journal.js";
 import { fakeActionPerformer } from "./testing.js";
@@ -134,11 +134,13 @@ function executor(
     execute: async (invocation: ToolInvocation) =>
       parsed(
         (
-          await tools.execute(invocation, {
-            runId: run.runId,
-            signal: run.abort.signal,
-            isRevoked: () => false,
-          })
+          await Effect.runPromise(
+            tools.execute(invocation, {
+              runId: run.runId,
+              signal: run.abort.signal,
+              isRevoked: () => false,
+            }),
+          )
         ).outputJson,
       ),
   };

--- a/packages/brain/src/tool-executor.ts
+++ b/packages/brain/src/tool-executor.ts
@@ -24,7 +24,7 @@ import {
 import type { SessionIdentity } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS, type WireRecord } from "@sidecar/wire";
 import { readEither } from "@sidecar/wire/effect";
-import { Either } from "effect";
+import { Effect, Either } from "effect";
 import { estimateTokens } from "./compaction.js";
 import { UNCONFIRMED_ACTION_RESULT, UNKNOWN_ACTION_RESULT } from "./journal.js";
 import type { BrainActionExecution, BrainActionPerformer, BrainRoster } from "./performer.js";
@@ -161,52 +161,50 @@ export function createTurnToolExecutor(
    * mid-action is found as an action of unknown result and never replayed; a
    * checkpoint that will not land refuses the action instead, because an action
    * nobody could find afterwards is one the developer could not account
-   * for. An effect that throws after dispatch has answered nothing about
+   * for. An effect that dies after dispatch has answered nothing about
    * itself: the outcome is unknown, counted as such, and never a refusal.
    */
-  const performJournaled = async (
+  const performJournaled = (
     call: ToolInvocation,
     execution: BrainActionExecution,
-    effect: () => Promise<WireRecord>,
-  ): Promise<WireRecord> => {
-    const { run, generation } = context;
-    const outcomes = outcomesFor(call.name);
-    if (dependencies.runRevoked(run) || execution.isRevoked()) {
-      return outcomes.refuse(REFUSAL_REASON.RUN_REVOKED);
-    }
-    const recorded = generation.journal.get(run.runId, call.callId);
-    if (recorded) {
-      if (recorded.argumentsJson !== call.argumentsJson) {
-        return outcomes.refuse(REFUSAL_REASON.CALL_ID_REUSED);
+    effect: Effect.Effect<WireRecord>,
+  ): Effect.Effect<WireRecord> =>
+    Effect.gen(function* () {
+      const { run, generation } = context;
+      const outcomes = outcomesFor(call.name);
+      if (dependencies.runRevoked(run) || execution.isRevoked()) {
+        return outcomes.refuse(REFUSAL_REASON.RUN_REVOKED);
       }
-      return recorded.outputJson === undefined
-        ? outcomes.unknown(UNKNOWN_ACTION_RESULT.reason)
-        : parsedRecord(recorded.outputJson);
-    }
-    if (run.checkpointFailed) return outcomes.refuse(REFUSAL_REASON.NOT_CHECKPOINTED);
-    generation.journal.start({
-      runId: run.runId,
-      callId: call.callId,
-      name: call.name,
-      argumentsJson: call.argumentsJson,
-      startedAt: dependencies.now(),
+      const recorded = generation.journal.get(run.runId, call.callId);
+      if (recorded) {
+        if (recorded.argumentsJson !== call.argumentsJson) {
+          return outcomes.refuse(REFUSAL_REASON.CALL_ID_REUSED);
+        }
+        return recorded.outputJson === undefined
+          ? outcomes.unknown(UNKNOWN_ACTION_RESULT.reason)
+          : parsedRecord(recorded.outputJson);
+      }
+      if (run.checkpointFailed) return outcomes.refuse(REFUSAL_REASON.NOT_CHECKPOINTED);
+      generation.journal.start({
+        runId: run.runId,
+        callId: call.callId,
+        name: call.name,
+        argumentsJson: call.argumentsJson,
+        startedAt: dependencies.now(),
+      });
+      if (!(yield* Effect.promise(() => dependencies.checkpoint(context)))) {
+        generation.journal.forget(run.runId, call.callId);
+        run.checkpointFailed = true;
+        return outcomes.refuse(REFUSAL_REASON.NOT_CHECKPOINTED);
+      }
+      const output = yield* Effect.catchAllDefect(effect, () =>
+        Effect.succeed(outcomes.unknown(UNCONFIRMED_ACTION_RESULT.reason)),
+      );
+      if (output.status === ACTION_RESULT_STATUS.ACCEPTED) run.performedActions += 1;
+      if (output.status === UNKNOWN_ACTION_STATUS) run.unknownActions += 1;
+      generation.journal.settle(run.runId, call.callId, JSON.stringify(output), dependencies.now());
+      return output;
     });
-    if (!(await dependencies.checkpoint(context))) {
-      generation.journal.forget(run.runId, call.callId);
-      run.checkpointFailed = true;
-      return outcomes.refuse(REFUSAL_REASON.NOT_CHECKPOINTED);
-    }
-    let output: WireRecord;
-    try {
-      output = await effect();
-    } catch {
-      output = outcomes.unknown(UNCONFIRMED_ACTION_RESULT.reason);
-    }
-    if (output.status === ACTION_RESULT_STATUS.ACCEPTED) run.performedActions += 1;
-    if (output.status === UNKNOWN_ACTION_STATUS) run.unknownActions += 1;
-    generation.journal.settle(run.runId, call.callId, JSON.stringify(output), dependencies.now());
-    return output;
-  };
 
   /**
    * A memory provider's tool: a write through the same journal an action runs
@@ -214,61 +212,67 @@ export function createTurnToolExecutor(
    * standing and the scope it was bound to, and bounds the call's arguments
    * itself; a conversation with no provider refuses the tools.
    */
-  const memoryTool = async (
+  const memoryTool = (
     call: ToolInvocation,
     input: WireRecord,
     execution: BrainActionExecution,
-  ): Promise<WireRecord> => {
-    const memory = dependencies.memory;
-    const tool = memory ? memoryToolNamed(memory.provider, call.name) : undefined;
-    if (!memory || !tool) return rejection(REFUSAL_REASON.NO_MEMORY);
-    const run = () => tool.execute(input, { ...execution, scope: memory.scope });
-    if (tool.effect === TOOL_EFFECT.WRITE) return performJournaled(call, execution, run);
-    if (execution.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-    return run();
-  };
+  ): Effect.Effect<WireRecord> =>
+    Effect.suspend(() => {
+      const memory = dependencies.memory;
+      const tool = memory ? memoryToolNamed(memory.provider, call.name) : undefined;
+      if (!memory || !tool) return Effect.succeed(rejection(REFUSAL_REASON.NO_MEMORY));
+      const run = Effect.promise(() => tool.execute(input, { ...execution, scope: memory.scope }));
+      if (tool.effect === TOOL_EFFECT.WRITE) return performJournaled(call, execution, run);
+      if (execution.isRevoked()) return Effect.succeed(rejection(REFUSAL_REASON.RUN_REVOKED));
+      return run;
+    });
 
   /** One of the brain's own modules under the context its kind takes: the reads, the briefing, delegation. */
-  const brainTool = async (
+  const brainTool = (
     call: ToolInvocation,
     input: WireRecord,
     execution: BrainActionExecution,
-  ): Promise<WireRecord> => {
-    const read = readToolNamed(call.name);
-    if (read) {
-      const roster = dependencies.roster();
-      return read.execute(input, {
-        ...execution,
-        roster: { text: roster.text, identities: roster.identities },
-        readTranscript: (identity) => dependencies.readWhole(identity, context),
-      });
-    }
-    if (call.name === ANNOUNCE_TOOL.name) {
-      return ANNOUNCE_TOOL.execute(input, {
-        ...execution,
-        announce: (briefing) => turn.onBriefing({ briefing, decidedAt: dependencies.now() }),
-      });
-    }
-    const session = sessionToolNamed(call.name);
-    if (session) {
-      return session.execute(input, {
-        ...execution,
-        children: dependencies.children,
-        policy: {
-          allowed: policy.allowed.map((tool) => tool.schema.name),
-          denied: policy.denied.map((denial) => denial.tool),
-        },
-        fork: () => forkSnapshotOf(context.context),
-        journal: (effect) => performJournaled(call, execution, effect),
-      });
-    }
-    return rejection(REFUSAL_REASON.NOT_OFFERED);
-  };
+  ): Effect.Effect<WireRecord> =>
+    Effect.suspend(() => {
+      const read = readToolNamed(call.name);
+      if (read) {
+        const roster = dependencies.roster();
+        return read.execute(input, {
+          ...execution,
+          roster: { text: roster.text, identities: roster.identities },
+          readTranscript: (identity) =>
+            Effect.promise(() => dependencies.readWhole(identity, context)),
+        });
+      }
+      if (call.name === ANNOUNCE_TOOL.name) {
+        return ANNOUNCE_TOOL.execute(input, {
+          ...execution,
+          announce: (briefing) => turn.onBriefing({ briefing, decidedAt: dependencies.now() }),
+        });
+      }
+      const session = sessionToolNamed(call.name);
+      if (session) {
+        return session.execute(input, {
+          ...execution,
+          children: dependencies.children,
+          policy: {
+            allowed: policy.allowed.map((tool) => tool.schema.name),
+            denied: policy.denied.map((denial) => denial.tool),
+          },
+          fork: () => forkSnapshotOf(context.context),
+          journal: (effect) => performJournaled(call, execution, effect),
+        });
+      }
+      return Effect.succeed(rejection(REFUSAL_REASON.NOT_OFFERED));
+    });
 
-  return {
-    execute: async (call: ToolInvocation, runtimeContext: ToolExecutionContext) => {
+  const dispatch = (
+    call: ToolInvocation,
+    runtimeContext: ToolExecutionContext,
+  ): Effect.Effect<WireRecord> =>
+    Effect.suspend(() => {
       const refused = refusalForPolicy(policy, call.name);
-      if (refused) return answer(refused);
+      if (refused) return Effect.succeed(refused);
       const execution: BrainActionExecution = {
         ...turn.execution,
         isRevoked: () => turn.execution.isRevoked() || runtimeContext.isRevoked(),
@@ -276,15 +280,19 @@ export function createTurnToolExecutor(
       const tool = descriptors.get(call.name);
       if (tool?.execution === TOOL_EXECUTION.PERFORMER) {
         const actionTool = actionToolNamed(call.name);
-        if (!actionTool) return answer(refusedActionOutput(REFUSAL_REASON.NOT_OFFERED));
+        if (!actionTool) return Effect.succeed(refusedActionOutput(REFUSAL_REASON.NOT_OFFERED));
         // The module runs inside the journal: admission, then the carrier,
         // whose answer is validated before the journal keeps it. One this
         // build cannot read is answered unknown: the action was dispatched,
         // and what became of it is exactly what could not be read.
-        return answer(
-          await performJournaled(call, execution, async () => {
+        return performJournaled(
+          call,
+          execution,
+          Effect.suspend(() => {
             const input = toolArguments(call.argumentsJson);
-            if (input === undefined) return refusedActionOutput(ACTION_REFUSAL.UNREADABLE);
+            if (input === undefined) {
+              return Effect.succeed(refusedActionOutput(ACTION_REFUSAL.UNREADABLE));
+            }
             return actionTool.execute(input, {
               ...execution,
               admission: dependencies.actions.admission(execution),
@@ -302,19 +310,19 @@ export function createTurnToolExecutor(
       const input = toolArguments(call.argumentsJson) ?? {};
       if (tool?.execution === TOOL_EXECUTION.WORKSPACE) {
         const workspaceTool = workspaceToolNamed(call.name);
-        if (!workspaceTool) return answer(rejection(REFUSAL_REASON.NOT_OFFERED));
-        return answer(
-          await workspaceTool.execute(input, {
-            ...execution,
-            workspace: dependencies.workspace,
-            journal: (effect) => performJournaled(call, execution, effect),
-          }),
-        );
+        if (!workspaceTool) return Effect.succeed(rejection(REFUSAL_REASON.NOT_OFFERED));
+        return workspaceTool.execute(input, {
+          ...execution,
+          workspace: dependencies.workspace,
+          journal: (effect) => performJournaled(call, execution, effect),
+        });
       }
-      if (tool?.execution === TOOL_EXECUTION.MEMORY) {
-        return answer(await memoryTool(call, input, execution));
-      }
-      return answer(await brainTool(call, input, execution));
-    },
+      if (tool?.execution === TOOL_EXECUTION.MEMORY) return memoryTool(call, input, execution);
+      return brainTool(call, input, execution);
+    });
+
+  return {
+    execute: (call: ToolInvocation, runtimeContext: ToolExecutionContext) =>
+      Effect.map(dispatch(call, runtimeContext), answer),
   };
 }

--- a/packages/brain/src/tools/action-tools.test.ts
+++ b/packages/brain/src/tools/action-tools.test.ts
@@ -10,6 +10,7 @@ import {
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { normalizeSession, SESSION_STATUS } from "@sidecar/session";
 import { emitJsonSchema } from "@sidecar/wire/effect";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { ACTION_TOOLS, type ActionToolContext, actionToolNamed } from "./action-tools.js";
 
@@ -76,7 +77,7 @@ test("execute admits over the roster admission reads for itself, then carries wh
   const tool = actionToolNamed("send_session_message");
   assert.ok(tool);
   const { ctx, carried, rosterReads } = context();
-  const output = await tool.execute(MESSAGE_INPUT, ctx);
+  const output = await Effect.runPromise(tool.execute(MESSAGE_INPUT, ctx));
   assert.equal(output.status, ACTION_OUTPUT_STATUS.ACCEPTED);
   assert.deepEqual(rosterReads, [1]);
   assert.deepEqual(carried, [
@@ -93,16 +94,15 @@ test("a call admission refuses carries nothing, and a standing already revoked r
   const tool = actionToolNamed("send_session_message");
   assert.ok(tool);
   const stranger = context();
-  const refused = await tool.execute(
-    { ...MESSAGE_INPUT, provider_session_id: "ghost" },
-    stranger.ctx,
+  const refused = await Effect.runPromise(
+    tool.execute({ ...MESSAGE_INPUT, provider_session_id: "ghost" }, stranger.ctx),
   );
   assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.deepEqual(stranger.carried, []);
   assert.deepEqual(stranger.rosterReads, [1]);
 
   const over = context(() => true);
-  const late = await tool.execute(MESSAGE_INPUT, over.ctx);
+  const late = await Effect.runPromise(tool.execute(MESSAGE_INPUT, over.ctx));
   assert.deepEqual(late, {
     status: ACTION_OUTPUT_STATUS.REFUSED,
     reason: ACTION_REFUSAL.TURN_OVER,
@@ -127,7 +127,7 @@ test("a standing revoked while admission read the roster refuses before the carr
       },
     },
   };
-  const late = await tool.execute(MESSAGE_INPUT, reading);
+  const late = await Effect.runPromise(tool.execute(MESSAGE_INPUT, reading));
   assert.deepEqual(late, {
     status: ACTION_OUTPUT_STATUS.REFUSED,
     reason: ACTION_REFUSAL.TURN_OVER,

--- a/packages/brain/src/tools/action-tools.ts
+++ b/packages/brain/src/tools/action-tools.ts
@@ -5,18 +5,19 @@ import {
   type ActionKind,
   type ActionOutputEnvelope,
   type AdmitContext,
-  admit,
+  admitEffect,
   refusedActionOutput,
   type ToolSpec,
   type ValidatedAction,
 } from "@sidecar/actions";
 import type { WireRecord } from "@sidecar/wire";
+import { Effect, Either } from "effect";
 import type { ToolContext, ToolModule } from "./tool-module.js";
 
 /**
  * The action tools as modules: one per row of the actions table, the
  * notebook's two writes included. Each one's `execute` is the whole gauntlet an action
- * runs — `admit()` first, against the roster admission reads for itself
+ * runs — `admitEffect()` first, against the roster admission reads for itself
  * through the readers the host supplies, then the carrier, which takes only
  * what admission minted. Nothing in a module knows the agent: the standing it
  * runs under, the readers, and the carrier all arrive in its context, so a
@@ -51,17 +52,21 @@ function defineActionTool(spec: ToolSpec<ActionFamily, ActionKind>): ActionToolM
     inputSchema: spec.request,
     kind: spec.kind,
     family: spec.family,
-    async execute(input: WireRecord, context: ActionToolContext): Promise<ActionOutputEnvelope> {
-      if (context.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER);
-      const admitted = await admit(
-        { kind: spec.kind, fields: input },
-        { ...context.admission, origin: context.origin, guard: context },
-      );
-      if (admitted.kind === undefined) return refusedActionOutput(admitted.reason);
-      // Asked once more after admission's own reads, so an action whose turn
-      // ended while the roster was refreshing is refused rather than carried.
-      if (context.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER);
-      return context.carry(admitted);
+    execute(input: WireRecord, context: ActionToolContext): Effect.Effect<ActionOutputEnvelope> {
+      return Effect.gen(function* () {
+        if (context.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER);
+        const admitted = yield* Effect.either(
+          admitEffect(
+            { kind: spec.kind, fields: input },
+            { ...context.admission, origin: context.origin, guard: context },
+          ),
+        );
+        if (Either.isLeft(admitted)) return refusedActionOutput(admitted.left.reason);
+        // Asked once more after admission's own reads, so an action whose turn
+        // ended while the roster was refreshing is refused rather than carried.
+        if (context.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER);
+        return yield* Effect.promise(() => context.carry(admitted.right));
+      });
     },
   };
 }

--- a/packages/brain/src/tools/announce-tool.test.ts
+++ b/packages/brain/src/tools/announce-tool.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { emitJsonSchema } from "@sidecar/wire/effect";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { ANNOUNCE_TOOL, type AnnounceToolContext } from "./announce-tool.js";
 import { BRAIN_TOOL, maximumBriefingLength } from "./names.js";
@@ -30,9 +31,13 @@ test("announce takes the briefing alone, hands it on bounded, and answers accept
   assert.deepEqual(node.required, ["briefing"]);
   assert.deepEqual(Object.keys(node.properties), ["briefing"]);
   const { ctx, announced } = context();
-  const answer = await ANNOUNCE_TOOL.execute({ briefing: "Checkout wants a decision." }, ctx);
+  const answer = await Effect.runPromise(
+    ANNOUNCE_TOOL.execute({ briefing: "Checkout wants a decision." }, ctx),
+  );
   assert.deepEqual(answer, { status: ACTION_RESULT_STATUS.ACCEPTED });
-  await ANNOUNCE_TOOL.execute({ briefing: "x".repeat(maximumBriefingLength + 40) }, ctx);
+  await Effect.runPromise(
+    ANNOUNCE_TOOL.execute({ briefing: "x".repeat(maximumBriefingLength + 40) }, ctx),
+  );
   assert.deepEqual(
     announced.map((briefing) => briefing.length),
     ["Checkout wants a decision.".length, maximumBriefingLength],
@@ -43,7 +48,7 @@ test("a briefing with no words is refused and nothing is handed on", async () =>
   const { ctx, announced } = context();
   const wordless: readonly WireRecord[] = [{}, { briefing: "   " }, { briefing: 4 }];
   for (const input of wordless) {
-    const refused = await ANNOUNCE_TOOL.execute(input, ctx);
+    const refused = await Effect.runPromise(ANNOUNCE_TOOL.execute(input, ctx));
     assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
     assert.equal(refused.reason, REFUSAL_REASON.EMPTY_BRIEFING);
   }

--- a/packages/brain/src/tools/announce-tool.ts
+++ b/packages/brain/src/tools/announce-tool.ts
@@ -1,6 +1,6 @@
 import { ACTION_RESULT_STATUS, text, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
 import { describeWire } from "@sidecar/wire/effect";
-import { Schema as EffectSchema } from "effect";
+import { Effect, Schema as EffectSchema } from "effect";
 import { BRAIN_TOOL, maximumBriefingLength } from "./names.js";
 import { rejection } from "./records.js";
 import { REFUSAL_REASON } from "./refusals.js";
@@ -58,10 +58,12 @@ export const ANNOUNCE_TOOL: AnnounceToolModule = {
     "when nothing is worth interrupting for. Never call it in a developer-ask turn: there your " +
     "final text is the reply.",
   inputSchema: ANNOUNCE_INPUT,
-  async execute(input: WireRecord, context: AnnounceToolContext): Promise<WireRecord> {
-    const briefing = text(input.briefing)?.slice(0, maximumBriefingLength);
-    if (!briefing) return rejection(REFUSAL_REASON.EMPTY_BRIEFING);
-    context.announce(briefing);
-    return { status: ACTION_RESULT_STATUS.ACCEPTED };
+  execute(input: WireRecord, context: AnnounceToolContext): Effect.Effect<WireRecord> {
+    return Effect.sync(() => {
+      const briefing = text(input.briefing)?.slice(0, maximumBriefingLength);
+      if (!briefing) return rejection(REFUSAL_REASON.EMPTY_BRIEFING);
+      context.announce(briefing);
+      return { status: ACTION_RESULT_STATUS.ACCEPTED };
+    });
   },
 };

--- a/packages/brain/src/tools/read-tools.test.ts
+++ b/packages/brain/src/tools/read-tools.test.ts
@@ -3,6 +3,7 @@ import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import type { SessionIdentity } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { emitJsonSchema } from "@sidecar/wire/effect";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { BRAIN_TOOL } from "./names.js";
 import { READ_TOOLS, type ReadToolContext, readToolNamed } from "./read-tools.js";
@@ -21,10 +22,11 @@ function context() {
     isRevoked: () => false,
     signal: new AbortController().signal,
     roster: { text: "Currently observed sessions:\n- abc", identities: [ABC] },
-    readTranscript: async (identity) => {
-      reads.push(identity);
-      return { status: ACTION_RESULT_STATUS.ACCEPTED, transcript: "whole" };
-    },
+    readTranscript: (identity) =>
+      Effect.sync(() => {
+        reads.push(identity);
+        return { status: ACTION_RESULT_STATUS.ACCEPTED, transcript: "whole" };
+      }),
   };
   return { ctx, reads };
 }
@@ -46,7 +48,7 @@ test("list_sessions answers the roster as the host renders it now, and reads not
   const { ctx, reads } = context();
   const tool = readToolNamed(BRAIN_TOOL.LIST_SESSIONS);
   assert.ok(tool);
-  assert.deepEqual(await tool.execute({}, ctx), { roster: ctx.roster.text });
+  assert.deepEqual(await Effect.runPromise(tool.execute({}, ctx)), { roster: ctx.roster.text });
   assert.deepEqual(reads, []);
 });
 
@@ -54,9 +56,8 @@ test("read_transcript reads only a session the roster holds, and refuses every o
   const { ctx, reads } = context();
   const tool = readToolNamed(BRAIN_TOOL.READ_TRANSCRIPT);
   assert.ok(tool);
-  const read = await tool.execute(
-    { provider_id: ABC.providerId, provider_session_id: ABC.providerSessionId },
-    ctx,
+  const read = await Effect.runPromise(
+    tool.execute({ provider_id: ABC.providerId, provider_session_id: ABC.providerSessionId }, ctx),
   );
   assert.equal(read.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.deepEqual(reads, [ABC]);
@@ -67,7 +68,7 @@ test("read_transcript reads only a session the roster holds, and refuses every o
     { provider_id: 7, provider_session_id: "abc" },
   ];
   for (const input of refused) {
-    const answer = await tool.execute(input, ctx);
+    const answer: WireRecord = await Effect.runPromise(tool.execute(input, ctx));
     assert.equal(answer.status, ACTION_RESULT_STATUS.REJECTED);
     assert.equal(answer.reason, REFUSAL_REASON.UNOBSERVED_SESSION);
   }

--- a/packages/brain/src/tools/read-tools.ts
+++ b/packages/brain/src/tools/read-tools.ts
@@ -2,7 +2,7 @@ import { maximumIdentifierLength } from "@sidecar/actions";
 import type { SessionIdentity } from "@sidecar/session";
 import type { UnparsedWireValue, WireRecord } from "@sidecar/wire";
 import { describeWire } from "@sidecar/wire/effect";
-import { Schema as EffectSchema } from "effect";
+import { Effect, Schema as EffectSchema } from "effect";
 import { BRAIN_TOOL } from "./names.js";
 import { identityFromRecord, rejection, sameIdentity } from "./records.js";
 import { REFUSAL_REASON } from "./refusals.js";
@@ -21,7 +21,7 @@ export interface ReadToolContext extends ToolContext {
   /** The roster as the host renders it now, and the identities a named session is held to. */
   readonly roster: { readonly text: string; readonly identities: readonly SessionIdentity[] };
   /** Reads one observed session's whole tail through the host, bounded there; the identity is one the roster holds. */
-  readTranscript(identity: SessionIdentity): Promise<WireRecord>;
+  readTranscript(identity: SessionIdentity): Effect.Effect<WireRecord>;
 }
 
 export type ReadToolModule = ToolModule<WireRecord, ReadToolContext>;
@@ -70,8 +70,8 @@ const LIST_SESSIONS: ReadToolModule = {
     "identity, status, and capabilities. The standing context already carries it; call this " +
     "only when you need it fresher than the turn's opening.",
   inputSchema: LIST_SESSIONS_INPUT,
-  async execute(_input: WireRecord, context: ReadToolContext): Promise<WireRecord> {
-    return { roster: context.roster.text };
+  execute(_input: WireRecord, context: ReadToolContext): Effect.Effect<WireRecord> {
+    return Effect.sync(() => ({ roster: context.roster.text }));
   },
 };
 
@@ -84,13 +84,15 @@ const READ_TRANSCRIPT: ReadToolModule = {
     "session answers with the developer's messages and the agent's replies, never its tool " +
     "activity; any other cloud session returns a refusal.",
   inputSchema: READ_TRANSCRIPT_INPUT,
-  async execute(input: WireRecord, context: ReadToolContext): Promise<WireRecord> {
-    const named = identityFromRecord(input);
-    const observed =
-      named !== undefined &&
-      context.roster.identities.some((listed) => sameIdentity(listed, named));
-    if (!named || !observed) return rejection(REFUSAL_REASON.UNOBSERVED_SESSION);
-    return context.readTranscript(named);
+  execute(input: WireRecord, context: ReadToolContext): Effect.Effect<WireRecord> {
+    return Effect.suspend(() => {
+      const named = identityFromRecord(input);
+      const observed =
+        named !== undefined &&
+        context.roster.identities.some((listed) => sameIdentity(listed, named));
+      if (!named || !observed) return Effect.succeed(rejection(REFUSAL_REASON.UNOBSERVED_SESSION));
+      return context.readTranscript(named);
+    });
   },
 };
 

--- a/packages/brain/src/tools/session-tools.test.ts
+++ b/packages/brain/src/tools/session-tools.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { emitJsonSchema } from "@sidecar/wire/effect";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { BRAIN_TOOL, maximumChildTaskLength, maximumSessionsConversationLines } from "./names.js";
 import { REFUSAL_REASON } from "./refusals.js";
@@ -123,10 +124,13 @@ function context(children: BrainChildAccess | undefined) {
     children,
     policy: { allowed: ["sessions_spawn"], denied: ["announce"] },
     fork: () => ({ items: [{ type: "message" }], estimatedTokens: 3 }),
-    journal: async (effect) => {
-      journaled += 1;
-      return effect();
-    },
+    journal: (effect) =>
+      Effect.flatMap(
+        Effect.sync(() => {
+          journaled += 1;
+        }),
+        () => effect,
+      ),
   };
   return { ctx, journaled: () => journaled };
 }
@@ -158,16 +162,18 @@ test("a spawn is bounded here, carries the turn's run, policy, and fork, runs th
   const { children, spawns } = delegation();
   const { ctx, journaled } = context(children);
   const spawn = toolNamed(BRAIN_TOOL.SESSIONS_SPAWN);
-  const receipt = await spawn.execute(
-    {
-      task: ` ${"t".repeat(maximumChildTaskLength + 10)} `,
-      label: " summary ",
-      context: CHILD_CONTEXT_MODE.FORK,
-      cleanup: CHILD_CLEANUP.DELETE,
-      run_timeout_seconds: 30,
-      expects_completion: false,
-    },
-    ctx,
+  const receipt = await Effect.runPromise(
+    spawn.execute(
+      {
+        task: ` ${"t".repeat(maximumChildTaskLength + 10)} `,
+        label: " summary ",
+        context: CHILD_CONTEXT_MODE.FORK,
+        cleanup: CHILD_CLEANUP.DELETE,
+        run_timeout_seconds: 30,
+        expects_completion: false,
+      },
+      ctx,
+    ),
   );
   assert.equal(journaled(), 1);
   assert.equal(receipt.status, ACTION_RESULT_STATUS.ACCEPTED);
@@ -186,15 +192,17 @@ test("a spawn is bounded here, carries the turn's run, policy, and fork, runs th
   assert.deepEqual(ask.policy, ctx.policy);
   assert.deepEqual(ask.fork(), ctx.fork());
   // Unreadable optional fields are left out rather than guessed at; an empty task never reaches the host.
-  await spawn.execute({ task: "look", context: "sideways", run_timeout_seconds: -1 }, ctx);
+  await Effect.runPromise(
+    spawn.execute({ task: "look", context: "sideways", run_timeout_seconds: -1 }, ctx),
+  );
   const second = spawns[1];
   assert.ok(second);
   assert.equal(second.context, undefined);
   assert.equal(second.timeoutMs, undefined);
-  const empty = await spawn.execute({ task: "  " }, ctx);
+  const empty = await Effect.runPromise(spawn.execute({ task: "  " }, ctx));
   assert.equal(empty.reason, REFUSAL_REASON.EMPTY_TASK);
   assert.equal(spawns.length, 2);
-  const refused = await spawn.execute({ task: "look", label: "refused" }, ctx);
+  const refused = await Effect.runPromise(spawn.execute({ task: "look", label: "refused" }, ctx));
   assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
   assert.equal(journaled(), 3);
 });
@@ -203,7 +211,7 @@ test("subagents lists as a read and cancels through the journal; a child not thi
   const { children, cancelled } = delegation();
   const { ctx, journaled } = context(children);
   const subagents = toolNamed(BRAIN_TOOL.SUBAGENTS);
-  const listed = await subagents.execute({}, ctx);
+  const listed = await Effect.runPromise(subagents.execute({}, ctx));
   assert.equal(journaled(), 0);
   assert.deepEqual(listed, {
     status: ACTION_RESULT_STATUS.ACCEPTED,
@@ -222,16 +230,20 @@ test("subagents lists as a read and cancels through the journal; a child not thi
       },
     ],
   });
-  const cancel = await subagents.execute({ action: "cancel", child_id: "child-1" }, ctx);
+  const cancel = await Effect.runPromise(
+    subagents.execute({ action: "cancel", child_id: "child-1" }, ctx),
+  );
   assert.deepEqual(cancel, { status: ACTION_RESULT_STATUS.ACCEPTED, cancelled: ["child-1"] });
   assert.equal(journaled(), 1);
-  const other = await subagents.execute({ action: "cancel", child_id: "someone-elses" }, ctx);
+  const other = await Effect.runPromise(
+    subagents.execute({ action: "cancel", child_id: "someone-elses" }, ctx),
+  );
   assert.equal(other.reason, REFUSAL_REASON.UNKNOWN_CHILD);
-  const unnamed = await subagents.execute({ action: "cancel" }, ctx);
+  const unnamed = await Effect.runPromise(subagents.execute({ action: "cancel" }, ctx));
   assert.equal(unnamed.reason, REFUSAL_REASON.NOT_OWN_CHILD);
   assert.deepEqual(cancelled, ["child-1"]);
 
-  const listing = await toolNamed(BRAIN_TOOL.SESSIONS_LIST).execute({}, ctx);
+  const listing = await Effect.runPromise(toolNamed(BRAIN_TOOL.SESSIONS_LIST).execute({}, ctx));
   assert.deepEqual(listing, {
     status: ACTION_RESULT_STATUS.ACCEPTED,
     conversations: [
@@ -245,15 +257,21 @@ test("subagents lists as a read and cancels through the journal; a child not thi
     ],
   });
   const history = toolNamed(BRAIN_TOOL.SESSIONS_HISTORY);
-  assert.deepEqual(await history.execute({ child_id: "child-1", limit: 999 }, ctx), {
-    status: ACTION_RESULT_STATUS.ACCEPTED,
-    lines: ["ask: hi", "reply: done"],
-  });
+  assert.deepEqual(
+    await Effect.runPromise(history.execute({ child_id: "child-1", limit: 999 }, ctx)),
+    {
+      status: ACTION_RESULT_STATUS.ACCEPTED,
+      lines: ["ask: hi", "reply: done"],
+    },
+  );
   assert.equal(
-    (await history.execute({ child_id: "someone-elses" }, ctx)).reason,
+    (await Effect.runPromise(history.execute({ child_id: "someone-elses" }, ctx))).reason,
     REFUSAL_REASON.UNKNOWN_CHILD,
   );
-  assert.equal((await history.execute({}, ctx)).reason, REFUSAL_REASON.NOT_OWN_CHILD);
+  assert.equal(
+    (await Effect.runPromise(history.execute({}, ctx))).reason,
+    REFUSAL_REASON.NOT_OWN_CHILD,
+  );
   assert.ok(maximumSessionsConversationLines > 0);
 });
 
@@ -266,7 +284,7 @@ test("with no delegation wired every session tool refuses, and none reaches the 
     { child_id: "c" },
   ];
   for (const [index, tool] of SESSION_TOOLS.entries()) {
-    const refused = await tool.execute(inputs[index] ?? {}, ctx);
+    const refused = await Effect.runPromise(tool.execute(inputs[index] ?? {}, ctx));
     assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
     assert.equal(refused.reason, REFUSAL_REASON.NO_CHILDREN);
   }

--- a/packages/brain/src/tools/session-tools.ts
+++ b/packages/brain/src/tools/session-tools.ts
@@ -22,7 +22,7 @@ import {
   type WireRecord,
 } from "@sidecar/wire";
 import { describeWire } from "@sidecar/wire/effect";
-import { Schema as EffectSchema } from "effect";
+import { Effect, Schema as EffectSchema } from "effect";
 import { BRAIN_TOOL, maximumChildTaskLength, maximumSessionsConversationLines } from "./names.js";
 import { rejection } from "./records.js";
 import { REFUSAL_REASON, SPAWN_REFUSAL_REASON } from "./refusals.js";
@@ -89,7 +89,7 @@ export interface SessionToolContext extends ToolContext {
   /** This conversation's active context as a fork would take it, read only if the host decides on one. */
   fork(): ForkSnapshot | undefined;
   /** Records an effect before it runs and its result before the model reads it; the executor's journal. */
-  journal(effect: () => Promise<WireRecord>): Promise<WireRecord>;
+  journal(effect: Effect.Effect<WireRecord>): Effect.Effect<WireRecord>;
 }
 
 export type SessionToolModule = ToolModule<WireRecord, SessionToolContext>;
@@ -277,32 +277,39 @@ const SESSIONS_SPAWN: SessionToolModule = {
     'conversation as its own item. Children start isolated unless context is "fork", ' +
     "which branches this conversation's current context into the child when it fits the cap.",
   inputSchema: SESSIONS_SPAWN_INPUT,
-  async execute(input: WireRecord, context: SessionToolContext): Promise<WireRecord> {
-    const children = context.children;
-    if (!children) return rejection(REFUSAL_REASON.NO_CHILDREN);
-    if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-    const task = text(input.task)?.trim().slice(0, maximumChildTaskLength);
-    if (!task) return rejection(REFUSAL_REASON.EMPTY_TASK);
-    const label = text(input.label)?.trim();
-    const seconds = input.run_timeout_seconds;
-    const timeoutMs =
-      isWireNumber(seconds) && Number.isInteger(seconds) && seconds >= 0
-        ? seconds * 1000
-        : undefined;
-    const ask: BrainChildSpawnAsk = {
-      task,
-      ...(label ? { label } : undefined),
-      ...(isChildContextMode(input.context) ? { context: input.context } : undefined),
-      ...(isChildCleanup(input.cleanup) ? { cleanup: input.cleanup } : undefined),
-      ...(timeoutMs !== undefined ? { timeoutMs } : undefined),
-      ...(isWireBoolean(input.expects_completion)
-        ? { expectsCompletion: input.expects_completion }
-        : undefined),
-      requesterRunId: context.runId,
-      policy: context.policy,
-      fork: () => context.fork(),
-    };
-    return context.journal(async () => spawnOutcomeRecord(await children.spawn(ask)));
+  execute(input: WireRecord, context: SessionToolContext): Effect.Effect<WireRecord> {
+    return Effect.suspend(() => {
+      const children = context.children;
+      if (!children) return Effect.succeed(rejection(REFUSAL_REASON.NO_CHILDREN));
+      if (context.isRevoked()) return Effect.succeed(rejection(REFUSAL_REASON.RUN_REVOKED));
+      const task = text(input.task)?.trim().slice(0, maximumChildTaskLength);
+      if (!task) return Effect.succeed(rejection(REFUSAL_REASON.EMPTY_TASK));
+      const label = text(input.label)?.trim();
+      const seconds = input.run_timeout_seconds;
+      const timeoutMs =
+        isWireNumber(seconds) && Number.isInteger(seconds) && seconds >= 0
+          ? seconds * 1000
+          : undefined;
+      const ask: BrainChildSpawnAsk = {
+        task,
+        ...(label ? { label } : undefined),
+        ...(isChildContextMode(input.context) ? { context: input.context } : undefined),
+        ...(isChildCleanup(input.cleanup) ? { cleanup: input.cleanup } : undefined),
+        ...(timeoutMs !== undefined ? { timeoutMs } : undefined),
+        ...(isWireBoolean(input.expects_completion)
+          ? { expectsCompletion: input.expects_completion }
+          : undefined),
+        requesterRunId: context.runId,
+        policy: context.policy,
+        fork: () => context.fork(),
+      };
+      return context.journal(
+        Effect.map(
+          Effect.promise(() => children.spawn(ask)),
+          spawnOutcomeRecord,
+        ),
+      );
+    });
   },
 };
 
@@ -313,26 +320,30 @@ const SUBAGENTS: SessionToolModule = {
     "when it was accepted and settled — or cancel one by id. Cancelling reaches every child " +
     "it spawned in turn. Check status only when debugging; completions arrive on their own.",
   inputSchema: SUBAGENTS_INPUT,
-  async execute(input: WireRecord, context: SessionToolContext): Promise<WireRecord> {
-    const children = context.children;
-    if (!children) return rejection(REFUSAL_REASON.NO_CHILDREN);
-    if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-    if (input.action === SUBAGENTS_ACTION.CANCEL) {
-      const childId = text(input.child_id);
-      if (!childId) return rejection(REFUSAL_REASON.NOT_OWN_CHILD);
-      return context.journal(async () => {
-        const cancelled = await children.cancel(childId);
-        return cancelled
-          ? cancellationRecord(childId, cancelled)
-          : rejection(REFUSAL_REASON.UNKNOWN_CHILD);
-      });
-    }
-    return {
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      children: (await children.list()).map(({ record, completion }) =>
-        childSummaryRecord(record, completion),
-      ),
-    };
+  execute(input: WireRecord, context: SessionToolContext): Effect.Effect<WireRecord> {
+    return Effect.gen(function* () {
+      const children = context.children;
+      if (!children) return rejection(REFUSAL_REASON.NO_CHILDREN);
+      if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
+      if (input.action === SUBAGENTS_ACTION.CANCEL) {
+        const childId = text(input.child_id);
+        if (!childId) return rejection(REFUSAL_REASON.NOT_OWN_CHILD);
+        return yield* context.journal(
+          Effect.map(
+            Effect.promise(() => children.cancel(childId)),
+            (cancelled) =>
+              cancelled
+                ? cancellationRecord(childId, cancelled)
+                : rejection(REFUSAL_REASON.UNKNOWN_CHILD),
+          ),
+        );
+      }
+      const listed = yield* Effect.promise(() => children.list());
+      return {
+        status: ACTION_RESULT_STATUS.ACCEPTED,
+        children: listed.map(({ record, completion }) => childSummaryRecord(record, completion)),
+      };
+    });
   },
 };
 
@@ -343,11 +354,14 @@ const SESSIONS_LIST: SessionToolModule = {
     "conversations, and child conversations — by key, kind, name, and last activity. These " +
     "are your own conversations, not the coding agents the roster lists.",
   inputSchema: SESSIONS_LIST_INPUT,
-  async execute(_input: WireRecord, context: SessionToolContext): Promise<WireRecord> {
-    const children = context.children;
-    if (!children) return rejection(REFUSAL_REASON.NO_CHILDREN);
-    if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-    return conversationListingRecord(await children.conversations(), children.sessionKey);
+  execute(_input: WireRecord, context: SessionToolContext): Effect.Effect<WireRecord> {
+    return Effect.gen(function* () {
+      const children = context.children;
+      if (!children) return rejection(REFUSAL_REASON.NO_CHILDREN);
+      if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
+      const directory = yield* Effect.promise(() => children.conversations());
+      return conversationListingRecord(directory, children.sessionKey);
+    });
   },
 };
 
@@ -357,19 +371,21 @@ const SESSIONS_HISTORY: SessionToolModule = {
     "Read the recent history of one child this conversation asked for, most recent last, " +
     `bounded to ${maximumSessionsConversationLines} lines. Only a child of this conversation answers.`,
   inputSchema: SESSIONS_HISTORY_INPUT,
-  async execute(input: WireRecord, context: SessionToolContext): Promise<WireRecord> {
-    const children = context.children;
-    if (!children) return rejection(REFUSAL_REASON.NO_CHILDREN);
-    if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-    const childId = text(input.child_id);
-    if (!childId) return rejection(REFUSAL_REASON.NOT_OWN_CHILD);
-    const limit =
-      isWireNumber(input.limit) && input.limit > 0
-        ? Math.min(Math.floor(input.limit), maximumSessionsConversationLines)
-        : maximumSessionsConversationLines;
-    const lines = await children.lines(childId, limit);
-    if (!lines) return rejection(REFUSAL_REASON.UNKNOWN_CHILD);
-    return { status: ACTION_RESULT_STATUS.ACCEPTED, lines: [...lines] };
+  execute(input: WireRecord, context: SessionToolContext): Effect.Effect<WireRecord> {
+    return Effect.gen(function* () {
+      const children = context.children;
+      if (!children) return rejection(REFUSAL_REASON.NO_CHILDREN);
+      if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
+      const childId = text(input.child_id);
+      if (!childId) return rejection(REFUSAL_REASON.NOT_OWN_CHILD);
+      const limit =
+        isWireNumber(input.limit) && input.limit > 0
+          ? Math.min(Math.floor(input.limit), maximumSessionsConversationLines)
+          : maximumSessionsConversationLines;
+      const lines = yield* Effect.promise(() => children.lines(childId, limit));
+      if (!lines) return rejection(REFUSAL_REASON.UNKNOWN_CHILD);
+      return { status: ACTION_RESULT_STATUS.ACCEPTED, lines: [...lines] };
+    });
   },
 };
 

--- a/packages/brain/src/tools/tool-module.ts
+++ b/packages/brain/src/tools/tool-module.ts
@@ -1,6 +1,6 @@
 import type { RunOrigin, SessionKey, ToolExecutionContext } from "@sidecar/runtime/vocabulary";
 import { isRecord, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
-import type { Schema } from "effect";
+import type { Effect, Schema } from "effect";
 
 /**
  * The shape every tool of the brain is declared in: what it is called, what
@@ -22,7 +22,7 @@ import type { Schema } from "effect";
  * The standing a tool's call runs under: which conversation and turn it
  * belongs to, which run, who opened it, and whether it still stands. The
  * origin is attribution, never a permission; `isRevoked()` is asked again
- * after every await and once more before an effect.
+ * after every read the call waited on and once more before an effect.
  */
 export interface ToolContext extends ToolExecutionContext {
   readonly conversationId: SessionKey;
@@ -47,6 +47,9 @@ export interface ToolModule<Output extends WireRecord, Context extends ToolConte
   readonly description: string;
   /** The tool's fields as the model is offered them and as a call is read; declared once, as an Effect `Schema`. */
   readonly inputSchema: Schema.Schema<unknown, UnparsedWireValue>;
-  /** Carries one call whose arguments parsed as a record; everything the call may do runs inside. */
-  execute(input: WireRecord, context: Context): Promise<Output>;
+  /**
+   * Carries one call whose arguments parsed as a record; everything the call
+   * may do runs inside, on the fiber of the loop that dispatched it.
+   */
+  execute(input: WireRecord, context: Context): Effect.Effect<Output>;
 }

--- a/packages/brain/src/tools/workspace-tools.test.ts
+++ b/packages/brain/src/tools/workspace-tools.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { emitJsonSchema } from "@sidecar/wire/effect";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { BRAIN_TOOL } from "./names.js";
 import { REFUSAL_REASON } from "./refusals.js";
@@ -24,10 +25,13 @@ function context(access: { workspace: BrainWorkspaceAccess | undefined }) {
     isRevoked: () => false,
     signal: new AbortController().signal,
     workspace,
-    journal: async (effect) => {
-      journaled += 1;
-      return effect();
-    },
+    journal: (effect) =>
+      Effect.flatMap(
+        Effect.sync(() => {
+          journaled += 1;
+        }),
+        () => effect,
+      ),
   };
   return { ctx, journaled: () => journaled };
 }
@@ -70,13 +74,15 @@ test("a write whose arguments are not the strings the tool takes is refused befo
     { name: "MEMORY.md", content: null },
   ];
   for (const input of malformed) {
-    const refused = await write.execute(input, ctx);
+    const refused: WireRecord = await Effect.runPromise(write.execute(input, ctx));
     assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
     assert.equal(refused.reason, REFUSAL_REASON.MALFORMED_ARGUMENTS);
   }
   assert.equal(journaled(), 0);
   assert.deepEqual(written, []);
-  const landed = await write.execute({ name: "MEMORY.md", content: "# MEMORY.md\n" }, ctx);
+  const landed = await Effect.runPromise(
+    write.execute({ name: "MEMORY.md", content: "# MEMORY.md\n" }, ctx),
+  );
   assert.deepEqual(landed, {
     status: ACTION_RESULT_STATUS.ACCEPTED,
     chars: "# MEMORY.md\n".length,
@@ -90,26 +96,28 @@ test("the reads answer the host's access directly and never through the journal,
   const read = workspaceToolNamed(BRAIN_TOOL.READ_WORKSPACE_FILE);
   const skill = workspaceToolNamed(BRAIN_TOOL.LOAD_SKILL);
   assert.ok(read && skill);
-  assert.deepEqual(await read.execute({ name: "USER.md" }, ctx), {
+  assert.deepEqual(await Effect.runPromise(read.execute({ name: "USER.md" }, ctx)), {
     status: ACTION_RESULT_STATUS.ACCEPTED,
     content: "content of USER.md",
   });
-  assert.deepEqual(await skill.execute({ location: "skills/x/SKILL.md" }, ctx), {
+  assert.deepEqual(await Effect.runPromise(skill.execute({ location: "skills/x/SKILL.md" }, ctx)), {
     status: ACTION_RESULT_STATUS.ACCEPTED,
     instructions: "do it",
     truncated: false,
   });
-  assert.equal((await read.execute({}, ctx)).reason, REFUSAL_REASON.MALFORMED_ARGUMENTS);
   assert.equal(
-    (await skill.execute({ location: 3 }, ctx)).reason,
+    (await Effect.runPromise(read.execute({}, ctx))).reason,
+    REFUSAL_REASON.MALFORMED_ARGUMENTS,
+  );
+  assert.equal(
+    (await Effect.runPromise(skill.execute({ location: 3 }, ctx))).reason,
     REFUSAL_REASON.MALFORMED_ARGUMENTS,
   );
   assert.equal(journaled(), 0);
   const without = context({ workspace: undefined });
   for (const tool of WORKSPACE_TOOLS) {
-    const refused = await tool.execute(
-      { name: "USER.md", content: "", location: "l" },
-      without.ctx,
+    const refused = await Effect.runPromise(
+      tool.execute({ name: "USER.md", content: "", location: "l" }, without.ctx),
     );
     assert.equal(refused.reason, REFUSAL_REASON.NO_WORKSPACE);
   }

--- a/packages/brain/src/tools/workspace-tools.ts
+++ b/packages/brain/src/tools/workspace-tools.ts
@@ -6,7 +6,7 @@ import {
   type WireRecord,
 } from "@sidecar/wire";
 import { describeWire } from "@sidecar/wire/effect";
-import { Schema as EffectSchema } from "effect";
+import { Effect, Schema as EffectSchema } from "effect";
 import { BRAIN_TOOL } from "./names.js";
 import { rejection } from "./records.js";
 import { REFUSAL_REASON } from "./refusals.js";
@@ -33,7 +33,7 @@ export interface WorkspaceToolContext extends ToolContext {
   /** The agent's own files, or nothing for an agent with no workspace, which refuses every call. */
   readonly workspace: BrainWorkspaceAccess | undefined;
   /** Records an effect before it runs and its result before the model reads it; the executor's journal. */
-  journal(effect: () => Promise<WireRecord>): Promise<WireRecord>;
+  journal(effect: Effect.Effect<WireRecord>): Effect.Effect<WireRecord>;
 }
 
 export type WorkspaceToolModule = ToolModule<WireRecord, WorkspaceToolContext>;
@@ -101,14 +101,18 @@ const READ_WORKSPACE_FILE: WorkspaceToolModule = {
     "MEMORY.md, BOOTSTRAP.md, or a dated note as memory/YYYY-MM-DD.md. Nothing " +
     "outside the workspace can be named.",
   inputSchema: READ_WORKSPACE_FILE_INPUT,
-  async execute(input: WireRecord, context: WorkspaceToolContext): Promise<WireRecord> {
-    if (!context.workspace) return rejection(REFUSAL_REASON.NO_WORKSPACE);
-    if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-    if (!isWireString(input.name)) return rejection(REFUSAL_REASON.MALFORMED_ARGUMENTS);
-    const read = await context.workspace.read(input.name);
-    return read.ok
-      ? { status: ACTION_RESULT_STATUS.ACCEPTED, content: read.content }
-      : rejection(read.reason);
+  execute(input: WireRecord, context: WorkspaceToolContext): Effect.Effect<WireRecord> {
+    return Effect.gen(function* () {
+      const workspace = context.workspace;
+      if (!workspace) return rejection(REFUSAL_REASON.NO_WORKSPACE);
+      if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
+      if (!isWireString(input.name)) return rejection(REFUSAL_REASON.MALFORMED_ARGUMENTS);
+      const name = input.name;
+      const read = yield* Effect.promise(() => workspace.read(name));
+      return read.ok
+        ? { status: ACTION_RESULT_STATUS.ACCEPTED, content: read.content }
+        : rejection(read.reason);
+    });
   },
 };
 
@@ -119,19 +123,24 @@ const WRITE_WORKSPACE_FILE: WorkspaceToolModule = {
     "MEMORY.md, USER.md, and dated notes current; read the file first so nothing is lost. " +
     "Content past the per-file bound is refused rather than cut.",
   inputSchema: WRITE_WORKSPACE_FILE_INPUT,
-  async execute(input: WireRecord, context: WorkspaceToolContext): Promise<WireRecord> {
-    const workspace = context.workspace;
-    if (!workspace) return rejection(REFUSAL_REASON.NO_WORKSPACE);
-    if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-    const { name, content } = input;
-    if (!isWireString(name) || !isWireString(content)) {
-      return rejection(REFUSAL_REASON.MALFORMED_ARGUMENTS);
-    }
-    return context.journal(async () => {
-      const written = await workspace.write(name, content);
-      return written.ok
-        ? { status: ACTION_RESULT_STATUS.ACCEPTED, chars: written.chars }
-        : rejection(written.reason);
+  execute(input: WireRecord, context: WorkspaceToolContext): Effect.Effect<WireRecord> {
+    return Effect.suspend(() => {
+      const workspace = context.workspace;
+      if (!workspace) return Effect.succeed(rejection(REFUSAL_REASON.NO_WORKSPACE));
+      if (context.isRevoked()) return Effect.succeed(rejection(REFUSAL_REASON.RUN_REVOKED));
+      const { name, content } = input;
+      if (!isWireString(name) || !isWireString(content)) {
+        return Effect.succeed(rejection(REFUSAL_REASON.MALFORMED_ARGUMENTS));
+      }
+      return context.journal(
+        Effect.map(
+          Effect.promise(() => workspace.write(name, content)),
+          (written) =>
+            written.ok
+              ? { status: ACTION_RESULT_STATUS.ACCEPTED, chars: written.chars }
+              : rejection(written.reason),
+        ),
+      );
     });
   },
 };
@@ -142,18 +151,22 @@ const LOAD_SKILL: WorkspaceToolModule = {
     "Load one skill's full instructions by the location the available skills list gave. Only " +
     "a listed location answers.",
   inputSchema: LOAD_SKILL_INPUT,
-  async execute(input: WireRecord, context: WorkspaceToolContext): Promise<WireRecord> {
-    if (!context.workspace) return rejection(REFUSAL_REASON.NO_WORKSPACE);
-    if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
-    if (!isWireString(input.location)) return rejection(REFUSAL_REASON.MALFORMED_ARGUMENTS);
-    const loaded = await context.workspace.loadSkill(input.location);
-    return loaded.ok
-      ? {
-          status: ACTION_RESULT_STATUS.ACCEPTED,
-          instructions: loaded.instructions,
-          truncated: loaded.truncated,
-        }
-      : rejection(loaded.reason);
+  execute(input: WireRecord, context: WorkspaceToolContext): Effect.Effect<WireRecord> {
+    return Effect.gen(function* () {
+      const workspace = context.workspace;
+      if (!workspace) return rejection(REFUSAL_REASON.NO_WORKSPACE);
+      if (context.isRevoked()) return rejection(REFUSAL_REASON.RUN_REVOKED);
+      if (!isWireString(input.location)) return rejection(REFUSAL_REASON.MALFORMED_ARGUMENTS);
+      const location = input.location;
+      const loaded = yield* Effect.promise(() => workspace.loadSkill(location));
+      return loaded.ok
+        ? {
+            status: ACTION_RESULT_STATUS.ACCEPTED,
+            instructions: loaded.instructions,
+            truncated: loaded.truncated,
+          }
+        : rejection(loaded.reason);
+    });
   },
 };
 

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -29,7 +29,7 @@ import {
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS, type WireRecord } from "@sidecar/wire";
 import { readEither } from "@sidecar/wire/effect";
-import { Effect, Either } from "effect";
+import { Effect, Either, Fiber, Option } from "effect";
 import { test } from "vitest";
 import {
   type BrainActionPerformerDependencies,
@@ -187,13 +187,15 @@ test("a session action reaches the performer only for a session the roster holds
   const { actions, performed, recorded } = performer();
   const identity = '"provider_id":"claude-code","provider_session_id":"session-a"';
 
-  const landed = await performCall(
-    actions,
-    {
-      name: ACTION_TOOL.SEND_SESSION_MESSAGE,
-      argumentsJson: `{${identity},"text":"go ahead"}`,
-    },
-    LIVE,
+  const landed = await Effect.runPromise(
+    performCall(
+      actions,
+      {
+        name: ACTION_TOOL.SEND_SESSION_MESSAGE,
+        argumentsJson: `{${identity},"text":"go ahead"}`,
+      },
+      LIVE,
+    ),
   );
   assert.equal(landed.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(performed.length, 1);
@@ -202,21 +204,21 @@ test("a session action reaches the performer only for a session the roster holds
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0]?.kind, "action");
 
-  const stranger = await performCall(
-    actions,
-    {
-      name: ACTION_TOOL.SEND_SESSION_MESSAGE,
-      argumentsJson: '{"provider_id":"claude-code","provider_session_id":"ghost","text":"hi"}',
-    },
-    LIVE,
+  const stranger = await Effect.runPromise(
+    performCall(
+      actions,
+      {
+        name: ACTION_TOOL.SEND_SESSION_MESSAGE,
+        argumentsJson: '{"provider_id":"claude-code","provider_session_id":"ghost","text":"hi"}',
+      },
+      LIVE,
+    ),
   );
   assert.equal(stranger.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.equal(performed.length, 1);
 
-  const unknown = await performCall(
-    actions,
-    { name: "delete_everything", argumentsJson: "{}" },
-    LIVE,
+  const unknown = await Effect.runPromise(
+    performCall(actions, { name: "delete_everything", argumentsJson: "{}" }, LIVE),
   );
   assert.deepEqual(unknown, {
     status: ACTION_OUTPUT_STATUS.REFUSED,
@@ -234,7 +236,7 @@ test("every answer is the envelope: a session action's target as the roster held
       : { status: ACTION_RESULT_STATUS.ACCEPTED },
   );
 
-  const sent = await performCall(actions, MESSAGE_CALL, LIVE);
+  const sent = await Effect.runPromise(performCall(actions, MESSAGE_CALL, LIVE));
   assert.deepEqual(sent, {
     status: ACTION_OUTPUT_STATUS.ACCEPTED,
     target: {
@@ -245,7 +247,7 @@ test("every answer is the envelope: a session action's target as the roster held
     },
   });
 
-  const stopped = await performCall(actions, CONTROL_CALL, LIVE);
+  const stopped = await Effect.runPromise(performCall(actions, CONTROL_CALL, LIVE));
   assert.deepEqual(stopped, {
     status: ACTION_OUTPUT_STATUS.ACCEPTED,
     target: {
@@ -258,7 +260,7 @@ test("every answer is the envelope: a session action's target as the roster held
     },
   });
 
-  const created = await performCall(actions, CREATE_CALL, LIVE);
+  const created = await Effect.runPromise(performCall(actions, CREATE_CALL, LIVE));
   assert.deepEqual(created, {
     status: ACTION_OUTPUT_STATUS.ACCEPTED,
     target: { providerId: "conductor" },
@@ -287,17 +289,17 @@ test("a carried action's refusal and lost answer keep their words apart: refused
     title: "Fix the flaky test",
     agentId: "cursor",
   };
-  assert.deepEqual(await performCall(actions, MESSAGE_CALL, LIVE), {
+  assert.deepEqual(await Effect.runPromise(performCall(actions, MESSAGE_CALL, LIVE)), {
     status: ACTION_OUTPUT_STATUS.REFUSED,
     reason: "the provider said no",
     target,
   });
-  assert.deepEqual(await performCall(actions, MESSAGE_CALL, LIVE), {
+  assert.deepEqual(await Effect.runPromise(performCall(actions, MESSAGE_CALL, LIVE)), {
     status: ACTION_OUTPUT_STATUS.REFUSED,
     reason: "no documented way in",
     target,
   });
-  assert.deepEqual(await performCall(actions, MESSAGE_CALL, LIVE), {
+  assert.deepEqual(await Effect.runPromise(performCall(actions, MESSAGE_CALL, LIVE)), {
     status: ACTION_OUTPUT_STATUS.UNKNOWN,
     reason: "the node went away",
     target,
@@ -318,7 +320,8 @@ test("a panel's answer is read in its own dialect: an acceptance keeps its note 
     performAppAction: async () => answers.shift() ?? {},
   });
   const outcomes = [];
-  while (answers.length > 0) outcomes.push(await performCall(actions, SETTING_CALL, LIVE));
+  while (answers.length > 0)
+    outcomes.push(await Effect.runPromise(performCall(actions, SETTING_CALL, LIVE)));
   const unreadable = {
     status: ACTION_OUTPUT_STATUS.REFUSED,
     reason: "The panel answered in a shape this build cannot read.",
@@ -336,26 +339,30 @@ test("a panel's answer is read in its own dialect: an acceptance keeps its note 
 test("memory actions are the main process's own, and the store's answer is the report", async () => {
   const { actions, facts, appActions } = performer();
 
-  const saved = await performCall(
-    actions,
-    {
-      name: ACTION_TOOL.REMEMBER_FACT,
-      argumentsJson: '{"words":"prefers concise answers"}',
-    },
-    LIVE,
+  const saved = await Effect.runPromise(
+    performCall(
+      actions,
+      {
+        name: ACTION_TOOL.REMEMBER_FACT,
+        argumentsJson: '{"words":"prefers concise answers"}',
+      },
+      LIVE,
+    ),
   );
   assert.equal(saved.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(facts().length, 1);
   const id = facts()[0]?.id;
   assert.ok(id);
 
-  const forgotten = await performCall(
-    actions,
-    {
-      name: ACTION_TOOL.FORGET_FACT,
-      argumentsJson: JSON.stringify({ id }),
-    },
-    LIVE,
+  const forgotten = await Effect.runPromise(
+    performCall(
+      actions,
+      {
+        name: ACTION_TOOL.FORGET_FACT,
+        argumentsJson: JSON.stringify({ id }),
+      },
+      LIVE,
+    ),
   );
   assert.equal(forgotten.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(facts().length, 0);
@@ -381,8 +388,8 @@ it.effect(
           forget: async () => false,
         },
       });
-      const [first, second] = yield* Effect.promise(() =>
-        Promise.all([
+      const [first, second] = yield* Effect.all(
+        [
           performCall(
             actions,
             { name: ACTION_TOOL.REMEMBER_FACT, argumentsJson: '{"words":"from thread one"}' },
@@ -393,7 +400,8 @@ it.effect(
             { name: ACTION_TOOL.REMEMBER_FACT, argumentsJson: '{"words":"from thread two"}' },
             LIVE,
           ),
-        ]),
+        ],
+        { concurrency: "unbounded" },
       );
       assert.equal(first.status, ACTION_RESULT_STATUS.ACCEPTED);
       assert.equal(second.status, ACTION_RESULT_STATUS.ACCEPTED);
@@ -422,25 +430,29 @@ test("an app action is validated against the reported guide before a renderer ca
   };
   const { actions, appActions } = performer({ appGuide: () => guide });
 
-  const changed = await performCall(
-    actions,
-    {
-      name: ACTION_TOOL.CHANGE_APP_SETTING,
-      argumentsJson: '{"setting_id":"voice_captions","value":"on"}',
-    },
-    LIVE,
+  const changed = await Effect.runPromise(
+    performCall(
+      actions,
+      {
+        name: ACTION_TOOL.CHANGE_APP_SETTING,
+        argumentsJson: '{"setting_id":"voice_captions","value":"on"}',
+      },
+      LIVE,
+    ),
   );
   assert.equal(changed.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(appActions.length, 1);
   assert.equal(appActions[0]?.kind, "setting");
 
-  const unlisted = await performCall(
-    actions,
-    {
-      name: ACTION_TOOL.CHANGE_APP_SETTING,
-      argumentsJson: '{"setting_id":"launch_codes","value":"on"}',
-    },
-    LIVE,
+  const unlisted = await Effect.runPromise(
+    performCall(
+      actions,
+      {
+        name: ACTION_TOOL.CHANGE_APP_SETTING,
+        argumentsJson: '{"setting_id":"launch_codes","value":"on"}',
+      },
+      LIVE,
+    ),
   );
   assert.equal(unlisted.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.equal(appActions.length, 1);
@@ -448,7 +460,7 @@ test("an app action is validated against the reported guide before a renderer ca
 
 test("an action in a turn Luke opened himself runs under the same validators and is recorded as his own", async () => {
   const { actions, performed, recorded } = performer();
-  const outcome = await performCall(actions, MESSAGE_CALL, observationTurn());
+  const outcome = await Effect.runPromise(performCall(actions, MESSAGE_CALL, observationTurn()));
   assert.equal(outcome.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(performed.length, 1);
   assert.equal(recorded.length, 1);
@@ -521,10 +533,12 @@ test("a turn revoked while the roster refreshed is refused before the effect, an
       revoked = true;
     },
   });
-  const refused = await performCall(
-    actions,
-    MESSAGE_CALL,
-    developerTurn(() => revoked),
+  const refused = await Effect.runPromise(
+    performCall(
+      actions,
+      MESSAGE_CALL,
+      developerTurn(() => revoked),
+    ),
   );
   assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.equal(refused.reason, ACTION_REFUSAL.TURN_OVER);
@@ -541,10 +555,12 @@ test("a turn revoked while the creation defaults were read is refused before the
       return {};
     },
   });
-  const refused = await performCall(
-    actions,
-    CREATE_CALL,
-    developerTurn(() => revoked),
+  const refused = await Effect.runPromise(
+    performCall(
+      actions,
+      CREATE_CALL,
+      developerTurn(() => revoked),
+    ),
   );
   assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.deepEqual(performed, []);
@@ -554,10 +570,10 @@ test("a turn revoked while the creation defaults were read is refused before the
 test("a revoked turn reaches no memory write and no renderer action", async () => {
   const { actions, facts, appActions } = performer({ appGuide: () => CAPTIONS_GUIDE });
   const over = developerTurn(() => true);
-  const notSaved = await performCall(actions, REMEMBER_CALL, over);
+  const notSaved = await Effect.runPromise(performCall(actions, REMEMBER_CALL, over));
   assert.equal(notSaved.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.deepEqual(facts(), []);
-  const notChanged = await performCall(actions, SETTING_CALL, over);
+  const notChanged = await Effect.runPromise(performCall(actions, SETTING_CALL, over));
   assert.equal(notChanged.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.deepEqual(appActions, []);
 });
@@ -571,7 +587,7 @@ test("an action is validated against the roster as refreshed inside the turn, no
       sessions = [];
     },
   });
-  const refused = await performCall(actions, MESSAGE_CALL, LIVE);
+  const refused = await Effect.runPromise(performCall(actions, MESSAGE_CALL, LIVE));
   assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.deepEqual(performed, []);
 });
@@ -587,7 +603,7 @@ test("a creation is admitted against the projects the same pass reported, and th
       projects = [LISTED_PROJECT];
     },
   });
-  const created = await performCall(actions, CREATE_CALL, LIVE);
+  const created = await Effect.runPromise(performCall(actions, CREATE_CALL, LIVE));
   assert.equal(created.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(passes, 1);
   assert.deepEqual(
@@ -627,19 +643,17 @@ it.effect(
         };
         // Only a creation reads the defaults, so each held read is exercised by the
         // act that actually waits on it.
-        const pending = performCall(
-          h.actions,
-          held === "refreshSessions" ? MESSAGE_CALL : CREATE_CALL,
-          execution,
+        const pending = yield* Effect.fork(
+          performCall(
+            h.actions,
+            held === "refreshSessions" ? MESSAGE_CALL : CREATE_CALL,
+            execution,
+          ),
         );
-        let settled = false;
-        void pending.then(() => {
-          settled = true;
-        });
         yield* waitFor(() => invoked);
-        assert.equal(settled, false);
+        assert.equal(Option.isNone(yield* pending.poll), true);
         controller.abort();
-        const outcome = yield* Effect.promise(() => pending);
+        const outcome = yield* Fiber.join(pending);
         assert.equal(outcome.status, ACTION_OUTPUT_STATUS.REFUSED);
         assert.deepEqual(h.performed, []);
         release?.();

--- a/packages/runtime/src/execution.ts
+++ b/packages/runtime/src/execution.ts
@@ -128,9 +128,15 @@ export interface ToolExecutionContext {
   isRevoked(): boolean;
 }
 
-/** Executes one admitted invocation; the host supplies it, and everything it may do is the host's rule. */
+/**
+ * Executes one admitted invocation; the host supplies it, and everything it
+ * may do is the host's rule. The call is an effect, so it runs on the fiber
+ * of the loop that dispatched it: the batch a runtime holds uninterruptible
+ * is what keeps a dispatched effect from being cut off from its result, and
+ * nothing crosses a promise between the two.
+ */
 export interface ToolExecutor {
-  execute(invocation: ToolInvocation, context: ToolExecutionContext): Promise<ToolResult>;
+  execute(invocation: ToolInvocation, context: ToolExecutionContext): Effect.Effect<ToolResult>;
 }
 
 export const REASONING_EFFORT = {


### PR DESCRIPTION
P12-15c — the tool executor seam, as far as it goes in one PR.

## Summary

- `ToolExecutor.execute` in `packages/runtime/src/execution.ts` answers an
  `Effect<ToolResult>`, so the brain's tool loop dispatches a call on its own
  fiber (`Effect.catchAllDefect` where `Effect.tryPromise` stood) rather than
  across a promise. No OpenClaw port consumes the seam, so no Promise adaptor
  was added and no shim row with it.
- Every tool module of the brain answers an effect with it: `ToolModule.execute`
  is `Effect.Effect<Output>`, and the action, read, session, workspace, and
  announce modules follow. The executor's own policy door, journal, and
  dispatch are one effect around another — `performJournaled` takes the
  effect it records rather than a thunk it awaits, and a module that *dies*
  after dispatch is still the unknown outcome it always was.
- The action modules admit through `admitEffect` directly: the gauntlet no
  longer crosses `admit()`'s promise door on the brain's path.
- `runHostedTool` in `apps/web/server/hosted/brain-host/tools.ts` answers an
  effect, which the hosted brain's tool step yields instead of wrapping in
  `Effect.promise`.
- What stays a promise inside the executor is what the host hands it: the
  turn's checkpoint, the whole-transcript read, the child and workspace
  access, the memory provider's own tools, and the carrier an admitted action
  reaches. `read-prefetch.ts`'s slot memo is a promise, so its read of the
  transcript module goes through `carryOn`, the brain's one door, which the
  ADR already records.

### What this row does not do, and why

The row as tabled also deletes `admit()`'s Promise door and moves
`ActionAdmissionReads` and `SessionActionPerformer.perform` onto effects. Doing
all of it in one PR is over a thousand changed lines through
`@sidecar/actions`, `@sidecar/brain`, `@sidecar/host`, `apps/web`, and
`@sidecar/providers`, so the row split on contact at the seam it is named for.
The remaining slices, each of which this PR unblocks:

- **P12-15d** — `ActionAdmissionReads` (`ActionRoster.read`,
  `ActionProjects.read`/`defaults`, `guardedRead`) answer effects; the brain's
  and host's action performers answer effects; `composeBrain`'s
  `refreshSessions` handed-runtime row goes.
- **P12-15e** — `SessionActionPerformer.perform`, `settleHostedWrite`, and the
  row actions answer effects; `composeObservation`'s `pokeRefresh` row goes;
  session-action-performer's settings read yields the store.
- **P12-15f** — `executeSessionAction` and the two testing doors over it
  (`@sidecar/actions`'s `tool-call.ts`, the provider contract's oracle) answer
  effects, which is what `admit()`'s door now waits on; the door, its ADR
  paragraph, and its `runShims` row go together there.

The ADR's own rows are re-pointed to say exactly that: the `admit()` door and
`pokeRefresh` no longer name the `ToolExecutor` seam as their blocker, and the
paragraph that called `ToolExecutor` permanently Promise-shaped beside
`ModelAdapter` and `ContextEngine` is corrected — it was owned by the brain,
not by identity above the runtime, which is why this change needs no promise
view built back out of it.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green (twice: before and
  after the rebase onto `origin/main`).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this
  workspace is Linux and no renderer, panel, or window code changed.

### Visual evidence

- Fixture screenshots inspected: `not attached` — no UI change.

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — green; no renderer or UI file is touched, so `verify.sh` has nothing to show.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — no fixture file changed; `inputSchema` on every module is the same value it was.
- [x] Gateway envelope goldens unchanged. (CI) — no gateway file touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no assertion added; `admit.ts` is unchanged.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no ported file is touched; none consumes `ToolExecutor`, which is why the seam needed no adaptor.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and the shims `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-run-promise-outside-edges`) — no run added outside tests; the JSON is unchanged because no shim was added or deleted. The two runs that read as new (`packages/brain/src/read-prefetch.ts` reaching `carryOn`, and the test bodies) are the existing door and files exempt by extension.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`/`fs.watch` outside the files `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-raw-async-primitives`) — none added; `action-performer.test.ts` lost one `new Promise` by forking the pending call instead.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — unchanged: every touched test file has exactly the `test`/`it.effect` count it has on `origin/main`; brain 545 passed + 1 skipped, host 343, web 834.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced; `carry.ts`'s `@deprecated` note is corrected to stop naming the seam that no longer keeps it.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — no `CLAUDE.md`/`AGENTS.md` sentence names the tool executor or a tool module (checked by grep); the sentences that do name them live in `docs/adr/0001-effect.md` and are edited here. `CLAUDE.md` is a symlink to `AGENTS.md`, so the pair is byte-identical by construction.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — `effect` was already a declared `catalog:` dependency of `@sidecar/runtime`, `@sidecar/brain`, and `apps/web`; no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — only `effect` itself is imported, in packages that already import it.

## Notes

- Blockers or follow-up verification: the three slices named above. None of
  them is opened from this workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b2354ca6-cbc2-449e-bbfe-a9b03897bded)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)