### PR TITLE
refactor(host): the session action performer and the hosted write settle as effects

### DIFF
--- a/apps/desktop/src/main/ipc/session-acts.test.ts
+++ b/apps/desktop/src/main/ipc/session-acts.test.ts
@@ -1,13 +1,17 @@
 import assert from "node:assert/strict";
-import type { SessionRowActions } from "@sidecar/host";
-import type { SessionIdentity } from "@sidecar/session";
+import type { SessionIdentity, SessionWriteResult } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { Effect } from "effect";
 import type { WebContents } from "electron";
 import { test } from "vitest";
 import { ACT_KIND, ACT_OUTCOME_STATUS } from "#shared/messages/acts";
 import { ActRefused, type ActSender, createActRouter } from "../act-router";
-import { ROW_WRITE_REFUSAL, sessionActRows, WRITE_REFUSAL } from "./session-acts";
+import {
+  ROW_WRITE_REFUSAL,
+  type SessionActsDependencies,
+  sessionActRows,
+  WRITE_REFUSAL,
+} from "./session-acts";
 
 // SAFETY: the router reads the sender by identity alone; one inert object is one window.
 const SENDER = {} as WebContents;
@@ -24,9 +28,9 @@ interface Asked {
 }
 
 /** The host's row writes as this process reaches them, recording what crossed and answering as told. */
-function fixture(answer: () => Promise<Awaited<ReturnType<SessionRowActions["sendMessage"]>>>) {
+function fixture(answer: () => Promise<SessionWriteResult>) {
   const asked: Asked = { messages: [], controls: [] };
-  const writes: SessionRowActions = {
+  const writes: SessionActsDependencies["writes"] = {
     sendMessage: async (identity, text) => {
       asked.messages.push({ identity, text });
       return answer();

--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -1,21 +1,38 @@
-import { OPEN_REFUSAL, type SessionActionPerformer, type SessionRowActions } from "@sidecar/host";
-import type { SessionOpenResult, SessionWriteResult } from "@sidecar/session";
+import { OPEN_REFUSAL } from "@sidecar/host";
+import type {
+  SessionApplicationId,
+  SessionIdentity,
+  SessionOpenResult,
+  SessionWriteResult,
+} from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { ACT_KIND } from "#shared/messages/acts";
 import { ActRefused, type ActRows, type ActSender } from "../act-router";
 
+/**
+ * The host's own session acts as this process reaches them: through the
+ * Gateway client, which answers promises, and never the host's in-process
+ * performer, whose acts are effects on the fiber that carries them.
+ */
 export interface SessionActsDependencies {
   /** The opens alone: a press is not a write, and reaches the roster's address without admission. */
-  performer: Pick<
-    SessionActionPerformer,
-    "openSession" | "openSessionApplication" | "openSessionChange"
-  >;
+  performer: {
+    openSession(identity: SessionIdentity): Promise<SessionOpenResult>;
+    openSessionApplication(
+      identity: SessionIdentity,
+      applicationId: SessionApplicationId,
+    ): Promise<SessionOpenResult>;
+    openSessionChange(identity: SessionIdentity): Promise<SessionOpenResult>;
+  };
   /**
    * The two writes a row asks for, carried to the host, whose `admit()`
    * decides each against the roster it reads for itself; nothing here decides
    * whether a session takes them.
    */
-  writes: SessionRowActions;
+  writes: {
+    sendMessage(identity: SessionIdentity, text: string): Promise<SessionWriteResult>;
+    executeControl(identity: SessionIdentity, controlId: string): Promise<SessionWriteResult>;
+  };
 }
 
 type SessionActKind =

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -263,26 +263,29 @@ the queued pass behind it as a daemon, which is exactly what the detached
 `Deferred` the pass settles rather than a promise it held.
 
 `composeObservation` in `packages/host/src/compose-observation.ts` is on the
-handed-runtime list: `settleHostedWrite` pokes a redraw after every landed
-session write, and both its callers — the session action performer the brain
-carries an admitted act through, and a row's own press — settle inside
-`SessionActionPerformer.perform`'s own promise rather than in a fiber. So the
-composer reads
-`Effect.runtime<never>()` out of its own build and hands those two a
-`pokeRefresh` that is `Runtime.runFork` of `loop.refresh` on it; it forks onto
-the runtime it was handed and never builds one, and `settleHostedWrite` itself
-runs nothing. It goes when that performer and the carrier above it answer
-effects; the `ToolExecutor` seam between them stopped being the blocker in
-P12-15c.
+handed-runtime list for what the brain still awaits of it. `pokeRefresh` is no
+longer one of those reasons: P12-15e made `SessionActionPerformer.perform`,
+the row's own two writes, and `settleHostedWrite` effects, so the redraw a
+landed write earns is a `yield*` of a poke that forks `loop.refresh` as a
+daemon, on the fiber the write itself is carried on, and nothing runs it. What
+is left is the brain's own promise-shaped reads: `workspaceDefaults`, which
+`ActionAdmissionReads` waits on as a promise, is run to one on the
+`Effect.runtime<never>()` this composer reads out of its own build, and
+`broadcastWorkspaceProjects` is forked onto the same runtime from the one
+place it still fires from a plain callback, `sessionRegistry.subscribe`'s
+listener. Both go when those reads and that listener answer effects.
 
 `composeBrain` in `packages/host/src/compose-brain.ts` is on the same list
-for the other half of the same seam: the roster and projects reads
-`admitEffect`'s `ActionAdmissionReads` waits on are still `Promise`s, and the
-pass admission asks for before every session action is one of them, so the
-brain action performer's `refreshSessions` is `Runtime.runPromise` of
-`loop.refresh` on the host's own runtime — the same `execution` runtime the
-store's asks and every turn already run on. It goes with `admit()`'s own
-Promise door, when those reads are effects.
+for the other half of the same seam, and runs two things on the `execution`
+runtime the store's asks and every turn already run on. The roster and
+projects reads `admitEffect`'s `ActionAdmissionReads` waits on are still
+`Promise`s, and the pass admission asks for before every session action is one
+of them, so the brain action performer's `refreshSessions` is
+`Runtime.runPromise` of `loop.refresh` there. The carrier below it is the
+other: `SessionActionPerformer.perform` answers an effect since P12-15e while
+`BrainActionPerformer.carry` is still a promise the action tool awaits, so the
+host's carrier is handed a `carry` that runs the performer's effect on that
+same runtime. Both go when those reads and that carrier answer effects.
 
 `compose-live.ts`'s entry covers a second run beside the timer bridge named
 above: `requestOnboardingBeat` decides whether to speak from the roster a
@@ -552,23 +555,16 @@ so it runs `arrivalBeat` to a promise on the same captured runtime beside its
 existing `gateOfferable` run, one line above where that already stood. Neither
 changes what file this is: `compose-live.ts` was already on the list.
 
-`composeObservation`'s entry above gains a second reason in P12-14f, beside
-`pokeRefresh`: every one of its nine `awaitedSettingsStore` reads moved onto
+`composeObservation`'s entry above was widened in P12-14f and narrowed again
+in P12-15e: every one of its nine `awaitedSettingsStore` reads moved onto
 `settings.store`, and `readWorkspaceDefaults`, `pruneWorkspaceProjectDefaults`,
-`rememberWorkspaceDefaults`, and `broadcastWorkspaceProjects` are effects now,
-but two collaborators outside this composer still hold what those effects used
-to be. `session-action-performer.ts` reads one field
-(`Pick<AwaitedSettingsStore, "get">`) and calls
-`rememberWorkspaceDefaults` as a promise, neither converted by this PR, so both
-are run to a promise on the same `Effect.runtime<never>()` `pokeRefresh` already
-reads, right where they are handed to `createSessionActionPerformer` — the
-same shape `awaitedSettingsStore` used, just answered locally instead of
-through that shim. `broadcastWorkspaceProjects` is forked onto the same
-runtime from the one place it still fires from a plain callback,
-`sessionRegistry.subscribe`'s listener, exactly as `void
-broadcastWorkspaceProjects()` fired it before. This half of the row goes once
-`session-action-performer.ts` answers effects itself; the file stays on the
-list regardless, for `pokeRefresh`'s own reason above.
+`rememberWorkspaceDefaults`, and `broadcastWorkspaceProjects` became effects,
+but the session action performer held two of them as promises — one field read
+(`Pick<AwaitedSettingsStore, "get">`) and `rememberWorkspaceDefaults` — which
+were run to promises where they were handed to
+`createSessionActionPerformer`. Both runs are gone: that performer takes
+`Pick<SettingsStore, "get">` and the remembering effect itself, and yields each
+on its own fiber.
 
 `compose-settings.ts` never joins this list: the observation composer's
 `broadcastWorkspaceProjects` is an effect since P12-14f, and its one caller
@@ -748,10 +744,11 @@ methods as the promises their unmigrated callers still hold, run on the
 runtime the host is composed on. The callers are the reason it exists rather
 than the store, and one by one they have moved off the face onto
 `settings.store` directly, each its own conversion: the observation and live
-composers in P12-14f (which still hand a runtime of their own to what they
-could not convert — `session-action-performer.ts`'s one field read and its
-`rememberWorkspaceDefaults` call, below — rather than reaching back through
-this face for it); `@sidecar/voice`'s `VoiceSettings` in P12-14g, an
+composers in P12-14f (which handed a runtime of their own to what they could
+not convert then — `session-action-performer.ts`'s one field read and its
+`rememberWorkspaceDefaults` call, both effects since P12-15e — rather than
+reaching back through this face for it); `@sidecar/voice`'s `VoiceSettings` in
+P12-14g, an
 Effect-returning interface now, the same shape `SettingsStore`'s own methods
 answer, so `compose-account.ts` hands `VoiceCapabilityAssembler` the store
 directly; and the settings composer's own account-preferences and
@@ -1256,7 +1253,7 @@ design decision stated as such:
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | with the last promise-shaped hosted route (`conversation-read.ts`, `events.ts`, `devices-vault-app.ts`); P10-16 moved every route it converted onto `RateBrake.check` |
 | `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P12-15 — the fence must stay synchronous, so this is bookkeeping rather than a scheduled deletion |
 | `compose-account.ts`'s runs of the account gate's links on the host's own runtime | P7-13b | P12-14b (see also below, put back in P12-14f, P12-14g, and P12-14h) |
-| `awaitedSettingsStore`, the settings store's own methods as the promises their unmigrated callers hold | P12-14c | P12-14i — the calendars composer's own account-preferences hydration reads left with P12-14e, the observation and live composers with P12-14f, `@sidecar/voice`'s `VoiceSettings` with P12-14g, and the settings composer's own chains with P12-14h; what still holds it is `compose-calendars.ts`'s two readers and the type `session-action-performer.ts` still names |
+| `awaitedSettingsStore`, the settings store's own methods as the promises their unmigrated callers hold | P12-14c | P12-14i — the calendars composer's own account-preferences hydration reads left with P12-14e, the observation and live composers with P12-14f, `@sidecar/voice`'s `VoiceSettings` with P12-14g, and the settings composer's own chains with P12-14h; what still holds it is `compose-calendars.ts`'s two readers, the session action performer having left in P12-15e |
 | `compose-account.ts`'s fork of `emitSessionReplay` onto the host's own runtime, from `AccountSessionManager`'s plain `onChange` callback | P12-14f | once `onChange` answers an effect a subscriber yields instead |
 | `compose-observation.ts`'s runs of `session-action-performer.ts`'s one field read and its `rememberWorkspaceDefaults` call, and its fork of `broadcastWorkspaceProjects` from `sessionRegistry.subscribe`'s callback, each on the composition's own runtime | P12-14f | once `session-action-performer.ts` answers effects itself |
 | `compose-account.ts`'s run of `transitionVoiceSource` on the host's own runtime, for `applyVoiceCredential`'s still-`Promise<void>` callers | P12-14g | once `applyVoiceCredential` itself answers an effect |

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -134,14 +134,16 @@ function performer(
   const appActions: BrainAppActionRequest["action"][] = [];
   let facts: readonly RememberedFact[] = [];
   const dependencies: BrainActionPerformerDependencies = {
+    carry: (effect) => Effect.runPromise(effect),
     sessionActions: {
-      perform: async (action) => {
-        performed.push(action);
-        return answer(action);
-      },
-      openSession: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
-      openSessionApplication: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
-      openSessionChange: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      perform: (action) =>
+        Effect.sync(() => {
+          performed.push(action);
+          return answer(action);
+        }),
+      openSession: () => Effect.succeed({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      openSessionApplication: () => Effect.succeed({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      openSessionChange: () => Effect.succeed({ status: ACTION_RESULT_STATUS.ACCEPTED }),
     },
     sessions: (): readonly Session[] => [observed],
     refreshSessions: async () => {},

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -37,7 +37,7 @@ import {
   type WireRecord,
 } from "@sidecar/wire";
 import { declareReader, emitJsonSchema, readEither } from "@sidecar/wire/effect";
-import { Schema as EffectSchema, Either } from "effect";
+import { type Effect, Schema as EffectSchema, Either } from "effect";
 import type { SessionActionPerformer } from "../session-action-performer.js";
 
 /** The developer's saved creation tie-breaks, as the projects context narrates them. */
@@ -54,6 +54,13 @@ interface BrainNotebookWriter {
 
 export interface BrainActionPerformerDependencies {
   sessionActions: SessionActionPerformer;
+  /**
+   * Carries the performer's own effect to the promise this carrier still
+   * answers, on the runtime the composition was built on. It goes when
+   * `BrainActionPerformer.carry` answers an effect itself, which is the last
+   * promise between the action tool's fiber and the provider write.
+   */
+  carry: <Value>(effect: Effect.Effect<Value>) => Promise<Value>;
   /** The roster as the brain was shown it: every observed session still worth a row. */
   sessions: () => readonly Session[];
   /**
@@ -222,7 +229,7 @@ export function createBrainActionPerformer(
     // The performer awaits once more of its own before a create or a spawn,
     // so the execution rides along to be asked again there.
     return actionOutputFromResult(
-      await dependencies.sessionActions.perform(action, execution),
+      await dependencies.carry(dependencies.sessionActions.perform(action, execution)),
       target,
     );
   };

--- a/packages/host/src/brain/wiring-children.test.ts
+++ b/packages/host/src/brain/wiring-children.test.ts
@@ -259,11 +259,13 @@ async function composed(
     broadcastRequests: () => undefined,
     onGenerationReplaced: () => undefined,
     actions: {
+      carry: (effect) => Effect.runPromise(effect),
       sessionActions: {
-        perform: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "not in test" }),
-        openSession: () => Promise.reject(new Error("not in test")),
-        openSessionApplication: () => Promise.reject(new Error("not in test")),
-        openSessionChange: () => Promise.reject(new Error("not in test")),
+        perform: () =>
+          Effect.succeed({ status: ACTION_RESULT_STATUS.REJECTED, reason: "not in test" }),
+        openSession: () => Effect.die(new Error("not in test")),
+        openSessionApplication: () => Effect.die(new Error("not in test")),
+        openSessionChange: () => Effect.die(new Error("not in test")),
       },
       sessions: () => [],
       refreshSessions: async () => undefined,

--- a/packages/host/src/brain/wiring-routing.test.ts
+++ b/packages/host/src/brain/wiring-routing.test.ts
@@ -211,11 +211,13 @@ async function composed(t: TestContext, gate?: Gate): Promise<Composed> {
     broadcastRequests: () => undefined,
     onGenerationReplaced: () => undefined,
     actions: {
+      carry: (effect) => Effect.runPromise(effect),
       sessionActions: {
-        perform: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "not in test" }),
-        openSession: () => Promise.reject(new Error("not in test")),
-        openSessionApplication: () => Promise.reject(new Error("not in test")),
-        openSessionChange: () => Promise.reject(new Error("not in test")),
+        perform: () =>
+          Effect.succeed({ status: ACTION_RESULT_STATUS.REJECTED, reason: "not in test" }),
+        openSession: () => Effect.die(new Error("not in test")),
+        openSessionApplication: () => Effect.die(new Error("not in test")),
+        openSessionChange: () => Effect.die(new Error("not in test")),
       },
       sessions: () => roster,
       refreshSessions: async () => undefined,

--- a/packages/host/src/brain/wiring.test.ts
+++ b/packages/host/src/brain/wiring.test.ts
@@ -49,11 +49,12 @@ function dependencies(overrides: Partial<BrainWiringDependencies> = {}) {
     broadcastRequests: () => undefined,
     onGenerationReplaced: () => undefined,
     actions: {
+      carry: (effect) => Effect.runPromise(effect),
       sessionActions: {
-        perform: async () => ({ status: "accepted" }),
-        openSession: async () => ({ status: "accepted" }),
-        openSessionApplication: async () => ({ status: "accepted" }),
-        openSessionChange: async () => ({ status: "accepted" }),
+        perform: () => Effect.succeed({ status: "accepted" }),
+        openSession: () => Effect.succeed({ status: "accepted" }),
+        openSessionApplication: () => Effect.succeed({ status: "accepted" }),
+        openSessionChange: () => Effect.succeed({ status: "accepted" }),
       },
       sessions: () => [],
       refreshSessions: async () => undefined,

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -251,6 +251,10 @@ export const composeBrain = (
         // here, on the host's own runtime; it goes when those reads are
         // effects.
         refreshSessions: () => Runtime.runPromise(execution)(observation.loop.refresh),
+        // The performer's own act is an effect since P12-15e, and the carrier
+        // above it is not, so the act is carried on the same runtime; it goes
+        // when `BrainActionPerformer.carry` answers an effect.
+        carry: (effect) => Runtime.runPromise(execution)(effect),
         workspaceProjects: observation.workspaceProjects,
         workspaceDefaults: observation.workspaceDefaults,
         appGuide: () => appGuide,

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -120,10 +120,9 @@ export const composeObservation = (
     const { settings, account, observationGate } = dependencies;
     const kernel = yield* HostKernelTag;
     const { runMode, report, now } = kernel;
-    // The runtime this composition is built on: what the poke forks onto, and
-    // what the settings store's own effects are run to a promise on for the
-    // two collaborators still promise-shaped — the session action performer's
-    // one field read, and its own remembered defaults.
+    // The runtime this composition is built on: what the brain's own
+    // workspace-defaults read is run to a promise on while that collaborator
+    // is promise-shaped, and what a roster listener forks its broadcast onto.
     const runtime = yield* Effect.runtime<never>();
     const late = yield* lateService<ObservationLinks>();
     const links = (): ObservationLinks => {
@@ -148,15 +147,12 @@ export const composeObservation = (
       ...account.token,
     });
     /**
-     * The redraw a landed write earns, as a synchronous caller can ask for
-     * it. A row's press and the brain's carried act both settle inside a
-     * promise the tool seam still holds, so the poke is forked onto the
-     * runtime this composition is being built on rather than awaited there;
-     * building a runtime here would be a second one.
+     * The redraw a landed write earns. A row's press and the brain's carried
+     * act each settle on their own fiber now, so the poke is a fork from
+     * there rather than a run: the write's answer goes back the moment the
+     * pass is started, exactly as the detached run it replaces did.
      */
-    const pokeRefresh = (): void => {
-      Runtime.runFork(runtime)(loop.refresh);
-    };
+    const pokeRefresh = Effect.asVoid(Effect.forkDaemon(Effect.suspend(() => loop.refresh)));
 
     const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
     let unsubscribeSessions: (() => void) | undefined;
@@ -305,16 +301,6 @@ export const composeObservation = (
         Effect.catchAll(() => Effect.void),
       );
 
-    function rememberWorkspaceDefaults(
-      providerId: CloudAgentProviderId,
-      providerProjectId: string,
-      namedSelection: WorkspaceAgentSelection | undefined,
-    ): Promise<void> {
-      return Runtime.runPromise(runtime)(
-        rememberWorkspaceDefaultsEffect(providerId, providerProjectId, namedSelection),
-      );
-    }
-
     function openCreatedWorkspaces(sessions: readonly Session[]): void {
       for (const created of createdWorkspaceOpens.claim(sessions, now())) {
         const link = created.detail.link;
@@ -331,12 +317,8 @@ export const composeObservation = (
       actions: actionClient,
       refreshSessions: pokeRefresh,
       sendsNetwork: runMode.sendsNetwork,
-      // The one field this collaborator still awaits, run to a promise on
-      // this composition's own runtime until it answers effects itself.
-      settingsStore: {
-        get: (field) => Runtime.runPromise(runtime)(settings.store.get(field)),
-      },
-      rememberWorkspaceDefaults,
+      settingsStore: settings.store,
+      rememberWorkspaceDefaults: rememberWorkspaceDefaultsEffect,
       expectCreatedWorkspace: (identity, at) => createdWorkspaceOpens.expect(identity, at),
       openCreatedWorkspaces: () => openCreatedWorkspaces(sessionRegistry.list()),
       recordProductEvent: settings.recordProductEvent,
@@ -480,10 +462,7 @@ export const composeObservation = (
       [GATEWAY_METHOD.SESSION_OPEN]: (params) => {
         const identity = params.identity;
         if (!isSessionIdentity(identity)) return invalid("identity must name a session");
-        return Effect.map(
-          Effect.promise(() => sessionActions.openSession(identity)),
-          (answer) => carried(answer),
-        );
+        return Effect.map(sessionActions.openSession(identity), (answer) => carried(answer));
       },
       [GATEWAY_METHOD.SESSION_OPEN_APPLICATION]: (params) => {
         const identity = params.identity;
@@ -493,36 +472,29 @@ export const composeObservation = (
           return invalid("applicationId is not one this build knows");
         }
         return Effect.map(
-          Effect.promise(() => sessionActions.openSessionApplication(identity, applicationId)),
+          sessionActions.openSessionApplication(identity, applicationId),
           (answer) => carried(answer),
         );
       },
       [GATEWAY_METHOD.SESSION_OPEN_CHANGE]: (params) => {
         const identity = params.identity;
         if (!isSessionIdentity(identity)) return invalid("identity must name a session");
-        return Effect.map(
-          Effect.promise(() => sessionActions.openSessionChange(identity)),
-          (answer) => carried(answer),
-        );
+        return Effect.map(sessionActions.openSessionChange(identity), (answer) => carried(answer));
       },
       [GATEWAY_METHOD.SESSION_SEND_MESSAGE]: (params) => {
         const identity = params.identity;
         const text = params.text;
         if (!isSessionIdentity(identity)) return invalid("identity must name a session");
         if (!isWireString(text)) return invalid("text must be a string");
-        return Effect.map(
-          Effect.promise(() => rowActions.sendMessage(identity, text)),
-          (answer) => carried(answer),
-        );
+        return Effect.map(rowActions.sendMessage(identity, text), (answer) => carried(answer));
       },
       [GATEWAY_METHOD.SESSION_EXECUTE_CONTROL]: (params) => {
         const identity = params.identity;
         const controlId = params.controlId;
         if (!isSessionIdentity(identity)) return invalid("identity must name a session");
         if (!isWireString(controlId)) return invalid("controlId must be a string");
-        return Effect.map(
-          Effect.promise(() => rowActions.executeControl(identity, controlId)),
-          (answer) => carried(answer),
+        return Effect.map(rowActions.executeControl(identity, controlId), (answer) =>
+          carried(answer),
         );
       },
       [GATEWAY_METHOD.WORKSPACE_PROJECTS]: () =>

--- a/packages/host/src/hosted-action-result.ts
+++ b/packages/host/src/hosted-action-result.ts
@@ -11,6 +11,7 @@ import {
 } from "@sidecar/hosted";
 import type { CloudAgentProviderId, SessionWriteResult } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
+import { Effect } from "effect";
 
 /** What a caller hears of a service call that ended short of the provider's own answer. */
 export const HOSTED_ACTION_ANSWER = {
@@ -74,23 +75,28 @@ export function hostedActionResult(
  * it may have already taken; only a write the service says its provider
  * cannot take at all moved nothing.
  *
- * The redraw is a poke and never a wait: `refresh` starts the observation
- * pass on the runtime the composition handed its caller and answers at once,
- * exactly as the detached promise it replaces did.
+ * The redraw is a poke and never a wait: `refresh` is the composition's own
+ * poke effect, which forks the observation pass and answers at once, so the
+ * write's answer reaches its caller no later than it did when the poke was a
+ * detached promise.
  */
 export function settleHostedWrite<Result extends SessionWriteResult>(
   result: Result,
   providerId: CloudAgentProviderId,
   counted: ProductSessionAction,
-  refresh: () => void,
+  refresh: Effect.Effect<void>,
   recordProductEvent: RecordProductEvent,
-): Result {
-  if (result.status !== ACTION_RESULT_STATUS.UNSUPPORTED) refresh();
-  if (result.status === ACTION_RESULT_STATUS.ACCEPTED) {
-    recordProductEvent(PRODUCT_EVENT.SESSION_ACTION_SEND, {
-      provider_id: providerId,
-      session_action: counted,
-    });
-  }
-  return result;
+): Effect.Effect<Result> {
+  return Effect.gen(function* () {
+    if (result.status !== ACTION_RESULT_STATUS.UNSUPPORTED) yield* refresh;
+    if (result.status === ACTION_RESULT_STATUS.ACCEPTED) {
+      yield* Effect.sync(() =>
+        recordProductEvent(PRODUCT_EVENT.SESSION_ACTION_SEND, {
+          provider_id: providerId,
+          session_action: counted,
+        }),
+      );
+    }
+    return result;
+  });
 }

--- a/packages/host/src/session-action-performer.test.ts
+++ b/packages/host/src/session-action-performer.test.ts
@@ -27,11 +27,10 @@ import {
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
 import { admittedForTest } from "@sidecar/wire/testing";
-import { Effect } from "effect";
-import { test } from "vitest";
+import { Effect, Fiber } from "effect";
 import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
 import { createSessionActionPerformer } from "./session-action-performer.js";
-import type { AwaitedSettingsStore } from "./settings-store-awaited.js";
+import type { SettingsStore } from "./settings-store.js";
 
 /** Waits for a real condition to become true, ticking Effect's own scheduler rather than a fixed drain. */
 function waitFor(condition: () => boolean, rounds = 300): Effect.Effect<void> {
@@ -108,14 +107,16 @@ function heldSettings(stored?: Readonly<Record<string, WorkspaceAgentSelection>>
   // SAFETY: the performer reads one field here, workspaceAgentDefaults, and
   // the pairing table is a legal value of it; the generic signature is
   // satisfied for that one field.
-  const store: Pick<AwaitedSettingsStore, "get"> = {
-    get: (async () => {
-      reads += 1;
-      await new Promise<void>((resolve) => {
-        release = resolve;
-      });
-      return stored;
-    }) as AwaitedSettingsStore["get"],
+  const store: Pick<SettingsStore, "get"> = {
+    get: (() =>
+      Effect.promise(() => {
+        reads += 1;
+        return new Promise<Readonly<Record<string, WorkspaceAgentSelection>> | undefined>(
+          (resolve) => {
+            release = () => resolve(stored);
+          },
+        );
+      })) as SettingsStore["get"],
   };
   return { store, release: () => release?.(), reads: () => reads };
 }
@@ -123,7 +124,7 @@ function heldSettings(stored?: Readonly<Record<string, WorkspaceAgentSelection>>
 interface FixtureOptions {
   outcome?: HostedActionOutcome;
   creation?: HostedActionWorkspaceOutcome;
-  settingsStore?: Pick<AwaitedSettingsStore, "get">;
+  settingsStore?: Pick<SettingsStore, "get">;
   openExternal?: (url: string, kind: HostNodeOpenKind) => Promise<void>;
   sendsNetwork?: boolean;
 }
@@ -163,19 +164,20 @@ function fixture(options: FixtureOptions = {}) {
       renameSession: async (target, name) => carry("rename-session", target, name),
       renameWorkspace: async (target, name) => carry("rename-workspace", target, name),
     },
-    refreshSessions: async () => {
+    refreshSessions: Effect.sync(() => {
       recorded.refreshes += 1;
-    },
+    }),
     sendsNetwork: options.sendsNetwork ?? true,
     // SAFETY: the performer reads one field here, workspaceAgentDefaults, and
     // an undefined answer is a legal value of it; the generic signature is
     // satisfied for that one field.
     settingsStore: options.settingsStore ?? {
-      get: (async () => undefined) as AwaitedSettingsStore["get"],
+      get: (() => Effect.succeed(undefined)) as SettingsStore["get"],
     },
-    rememberWorkspaceDefaults: async (...remembered) => {
-      recorded.remembered.push(remembered);
-    },
+    rememberWorkspaceDefaults: (...remembered) =>
+      Effect.sync(() => {
+        recorded.remembered.push(remembered);
+      }),
     expectCreatedWorkspace: (identity) => {
       recorded.expected.push(identity);
     },
@@ -233,13 +235,13 @@ it.effect(
       const settings = heldSettings();
       const { performer, recorded } = fixture({ settingsStore: settings.store });
       let revoked = false;
-      const pending = performer.perform(CREATE, { isRevoked: () => revoked });
+      const pending = yield* Effect.fork(performer.perform(CREATE, { isRevoked: () => revoked }));
       yield* waitFor(() => settings.reads() === 1);
       assert.equal(settings.reads(), 1);
       assert.deepEqual(recorded.carried, []);
       revoked = true;
       settings.release();
-      const result = yield* Effect.promise(() => pending);
+      const result = yield* Fiber.join(pending);
       assert.equal(result.status, ACTION_RESULT_STATUS.REJECTED);
       assert.equal(result.reason, ACTION_REFUSAL.TURN_OVER);
       assert.deepEqual(recorded.carried, []);
@@ -253,12 +255,12 @@ it.effect(
       const settings = heldSettings();
       const { performer, recorded } = fixture({ settingsStore: settings.store });
       let revoked = false;
-      const pending = performer.perform(SPAWN, { isRevoked: () => revoked });
+      const pending = yield* Effect.fork(performer.perform(SPAWN, { isRevoked: () => revoked }));
       yield* waitFor(() => settings.reads() === 1);
       assert.equal(settings.reads(), 1);
       revoked = true;
       settings.release();
-      const result = yield* Effect.promise(() => pending);
+      const result = yield* Fiber.join(pending);
       assert.equal(result.status, ACTION_RESULT_STATUS.REJECTED);
       assert.equal(result.reason, ACTION_REFUSAL.TURN_OVER);
       assert.deepEqual(recorded.carried, []);
@@ -272,24 +274,26 @@ it.effect(
       const settings = heldSettings();
       const { performer, recorded } = fixture({ settingsStore: settings.store });
       const controller = new AbortController();
-      const pending = performer.perform(CREATE, {
-        isRevoked: () => controller.signal.aborted,
-        signal: controller.signal,
-      });
+      const pending = yield* Effect.fork(
+        performer.perform(CREATE, {
+          isRevoked: () => controller.signal.aborted,
+          signal: controller.signal,
+        }),
+      );
       yield* waitFor(() => settings.reads() === 1);
       assert.equal(settings.reads(), 1);
       controller.abort();
       // Settles without the read being released.
-      const result = yield* Effect.promise(() => pending);
+      const result = yield* Fiber.join(pending);
       assert.equal(result.status, ACTION_RESULT_STATUS.REJECTED);
       settings.release();
       yield* settleMicrotasks();
       assert.deepEqual(recorded.carried, []);
       // A call with no signal waits the read out, as before.
-      const direct = performer.perform(CREATE, { isRevoked: () => false });
+      const direct = yield* Effect.fork(performer.perform(CREATE, { isRevoked: () => false }));
       yield* waitFor(() => settings.reads() === 2);
       settings.release();
-      assert.equal((yield* Effect.promise(() => direct)).status, ACTION_RESULT_STATUS.ACCEPTED);
+      assert.equal((yield* Fiber.join(direct)).status, ACTION_RESULT_STATUS.ACCEPTED);
       assert.equal(recorded.carried.length, 1);
     }),
 );
@@ -308,10 +312,10 @@ it.effect(
         },
       });
 
-      const creating = performer.perform(CREATE, { isRevoked: () => false });
+      const creating = yield* Effect.fork(performer.perform(CREATE, { isRevoked: () => false }));
       yield* waitFor(() => settings.reads() === 1);
       settings.release();
-      const result = yield* Effect.promise(() => creating);
+      const result = yield* Fiber.join(creating);
 
       assert.deepEqual(result, {
         status: ACTION_RESULT_STATUS.ACCEPTED,
@@ -361,14 +365,18 @@ it.effect("a spawn carries the stored model only for the very agent it pairs wit
     const withPair = fixture({ settingsStore: paired.store });
     const withOther = fixture({ settingsStore: other.store });
 
-    const spawning = withPair.performer.perform(SPAWN, { isRevoked: () => false });
+    const spawning = yield* Effect.fork(
+      withPair.performer.perform(SPAWN, { isRevoked: () => false }),
+    );
     yield* waitFor(() => paired.reads() === 1);
     paired.release();
-    assert.equal((yield* Effect.promise(() => spawning)).status, ACTION_RESULT_STATUS.ACCEPTED);
-    const unpaired = withOther.performer.perform(SPAWN, { isRevoked: () => false });
+    assert.equal((yield* Fiber.join(spawning)).status, ACTION_RESULT_STATUS.ACCEPTED);
+    const unpaired = yield* Effect.fork(
+      withOther.performer.perform(SPAWN, { isRevoked: () => false }),
+    );
     yield* waitFor(() => other.reads() === 1);
     other.release();
-    assert.equal((yield* Effect.promise(() => unpaired)).status, ACTION_RESULT_STATUS.ACCEPTED);
+    assert.equal((yield* Fiber.join(unpaired)).status, ACTION_RESULT_STATUS.ACCEPTED);
 
     assert.deepEqual(withPair.recorded.carried, [
       {
@@ -393,125 +401,147 @@ it.effect("a spawn carries the stored model only for the very agent it pairs wit
   }),
 );
 
-test("a message, a control, and the two renames each name the session and carry the ask to the service", async () => {
-  const { performer, recorded } = fixture();
+it.effect(
+  "a message, a control, and the two renames each name the session and carry the ask to the service",
+  () =>
+    Effect.gen(function* () {
+      const { performer, recorded } = fixture();
 
-  await performer.perform(MESSAGE);
-  await performer.perform(
-    admittedForTest({
-      kind: ACTION_KIND.CONTROL,
-      identity: WORKSPACE_IDENTITY,
-      control: { kind: ACTION_KIND.CONTROL, id: "cancel-run", label: "Stop" },
-      origin: RUN_ORIGIN.USER,
+      yield* performer.perform(MESSAGE);
+      yield* performer.perform(
+        admittedForTest({
+          kind: ACTION_KIND.CONTROL,
+          identity: WORKSPACE_IDENTITY,
+          control: { kind: ACTION_KIND.CONTROL, id: "cancel-run", label: "Stop" },
+          origin: RUN_ORIGIN.USER,
+        }),
+      );
+      yield* performer.perform(
+        admittedForTest({
+          kind: ACTION_KIND.RENAME_SESSION,
+          identity: WORKSPACE_IDENTITY,
+          name: "Flaky test",
+          origin: RUN_ORIGIN.USER,
+        }),
+      );
+      yield* performer.perform(
+        admittedForTest({
+          kind: ACTION_KIND.RENAME_WORKSPACE,
+          identity: WORKSPACE_IDENTITY,
+          name: "flaky-test",
+          origin: RUN_ORIGIN.USER,
+        }),
+      );
+
+      assert.deepEqual(recorded.carried, [
+        { route: "message", ...WORKSPACE_IDENTITY, ask: "ship it" },
+        { route: "control", ...WORKSPACE_IDENTITY, ask: "cancel-run" },
+        { route: "rename-session", ...WORKSPACE_IDENTITY, ask: "Flaky test" },
+        { route: "rename-workspace", ...WORKSPACE_IDENTITY, ask: "flaky-test" },
+      ]);
+      assert.equal(recorded.refreshes, 4);
+      assert.equal(recorded.events.length, 4);
     }),
-  );
-  await performer.perform(
-    admittedForTest({
-      kind: ACTION_KIND.RENAME_SESSION,
-      identity: WORKSPACE_IDENTITY,
-      name: "Flaky test",
-      origin: RUN_ORIGIN.USER,
+);
+
+it.effect(
+  "a session behind no cloud provider is refused before any call, and a fixture run creates nothing",
+  () =>
+    Effect.gen(function* () {
+      const { performer, recorded } = fixture({ sendsNetwork: false });
+
+      const local = yield* performer.perform(
+        admittedForTest({
+          kind: ACTION_KIND.MESSAGE,
+          identity: LOCAL_IDENTITY,
+          text: "hello",
+          origin: RUN_ORIGIN.USER,
+        }),
+      );
+      const offline = yield* performer.perform(CREATE);
+
+      assert.equal(local.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+      assert.equal(offline.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+      assert.deepEqual(recorded.carried, []);
+      assert.equal(recorded.refreshes, 0);
+      assert.deepEqual(recorded.events, []);
     }),
-  );
-  await performer.perform(
-    admittedForTest({
-      kind: ACTION_KIND.RENAME_WORKSPACE,
-      identity: WORKSPACE_IDENTITY,
-      name: "flaky-test",
-      origin: RUN_ORIGIN.USER,
+);
+
+it.effect(
+  "what the service answers reaches the brain as the result it means, and only a landed write is counted",
+  () =>
+    Effect.gen(function* () {
+      const lost = fixture({ outcome: { failure: HOSTED_ACTION_FAILURE.LOST } });
+      const refused = fixture({
+        outcome: {
+          answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." },
+        },
+      });
+      const unsupported = fixture({
+        outcome: { answer: { result: ACTION_RESULT_STATUS.UNSUPPORTED, reason: "No way in." } },
+      });
+
+      const uncertain = yield* lost.performer.perform(MESSAGE);
+      const rejected = yield* refused.performer.perform(MESSAGE);
+      const untaken = yield* unsupported.performer.perform(MESSAGE);
+
+      // An answer lost may have landed: the roster is drawn again, and nothing is counted.
+      assert.equal(uncertain.status, UNKNOWN_ACTION_STATUS);
+      assert.equal(lost.recorded.refreshes, 1);
+      assert.deepEqual(lost.recorded.events, []);
+      assert.deepEqual(rejected, {
+        status: ACTION_RESULT_STATUS.REJECTED,
+        reason: "That run has ended.",
+      });
+      assert.equal(refused.recorded.refreshes, 1);
+      // A write the provider cannot take at all moved nothing, so nothing is redrawn.
+      assert.equal(untaken.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+      assert.equal(unsupported.recorded.refreshes, 0);
     }),
-  );
+);
 
-  assert.deepEqual(recorded.carried, [
-    { route: "message", ...WORKSPACE_IDENTITY, ask: "ship it" },
-    { route: "control", ...WORKSPACE_IDENTITY, ask: "cancel-run" },
-    { route: "rename-session", ...WORKSPACE_IDENTITY, ask: "Flaky test" },
-    { route: "rename-workspace", ...WORKSPACE_IDENTITY, ask: "flaky-test" },
-  ]);
-  assert.equal(recorded.refreshes, 4);
-  assert.equal(recorded.events.length, 4);
-});
-
-test("a session behind no cloud provider is refused before any call, and a fixture run creates nothing", async () => {
-  const { performer, recorded } = fixture({ sendsNetwork: false });
-
-  const local = await performer.perform(
-    admittedForTest({
-      kind: ACTION_KIND.MESSAGE,
-      identity: LOCAL_IDENTITY,
-      text: "hello",
-      origin: RUN_ORIGIN.USER,
+it.effect(
+  "an open the brain carries tells the node it was asked of Luke, and a row press hands it an address",
+  () =>
+    Effect.gen(function* () {
+      const node = recordingOpens();
+      const { performer } = fixture({ openExternal: node.openExternal });
+      assert.equal((yield* performer.perform(OPEN)).status, ACTION_RESULT_STATUS.ACCEPTED);
+      assert.equal(
+        (yield* performer.openSession(WORKSPACE_IDENTITY)).status,
+        ACTION_RESULT_STATUS.ACCEPTED,
+      );
+      assert.deepEqual(
+        node.opens.map((open) => open.kind),
+        [HOST_NODE_OPEN_KIND.ASKED_SESSION, HOST_NODE_OPEN_KIND.ADDRESS],
+      );
+      assert.ok(node.opens.every((open) => open.url === WORKSPACE_LINK));
     }),
-  );
-  const offline = await performer.perform(CREATE);
+);
 
-  assert.equal(local.status, ACTION_RESULT_STATUS.UNSUPPORTED);
-  assert.equal(offline.status, ACTION_RESULT_STATUS.UNSUPPORTED);
-  assert.deepEqual(recorded.carried, []);
-  assert.equal(recorded.refreshes, 0);
-  assert.deepEqual(recorded.events, []);
-});
+it.effect(
+  "an open refused before the node, or lost at it, is answered without the node opening anything of its own",
+  () =>
+    Effect.gen(function* () {
+      const node = recordingOpens();
+      const { performer } = fixture({ openExternal: node.openExternal });
+      const absent = admittedForTest({
+        kind: ACTION_KIND.OPEN,
+        identity: {
+          providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+          providerSessionId: "workspace-gone",
+        },
+        origin: RUN_ORIGIN.USER,
+      });
+      assert.equal((yield* performer.perform(absent)).status, ACTION_RESULT_STATUS.UNSUPPORTED);
+      assert.equal(node.opens.length, 0);
 
-test("what the service answers reaches the brain as the result it means, and only a landed write is counted", async () => {
-  const lost = fixture({ outcome: { failure: HOSTED_ACTION_FAILURE.LOST } });
-  const refused = fixture({
-    outcome: { answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." } },
-  });
-  const unsupported = fixture({
-    outcome: { answer: { result: ACTION_RESULT_STATUS.UNSUPPORTED, reason: "No way in." } },
-  });
-
-  const uncertain = await lost.performer.perform(MESSAGE);
-  const rejected = await refused.performer.perform(MESSAGE);
-  const untaken = await unsupported.performer.perform(MESSAGE);
-
-  // An answer lost may have landed: the roster is drawn again, and nothing is counted.
-  assert.equal(uncertain.status, UNKNOWN_ACTION_STATUS);
-  assert.equal(lost.recorded.refreshes, 1);
-  assert.deepEqual(lost.recorded.events, []);
-  assert.deepEqual(rejected, {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: "That run has ended.",
-  });
-  assert.equal(refused.recorded.refreshes, 1);
-  // A write the provider cannot take at all moved nothing, so nothing is redrawn.
-  assert.equal(untaken.status, ACTION_RESULT_STATUS.UNSUPPORTED);
-  assert.equal(unsupported.recorded.refreshes, 0);
-});
-
-test("an open the brain carries tells the node it was asked of Luke, and a row press hands it an address", async () => {
-  const node = recordingOpens();
-  const { performer } = fixture({ openExternal: node.openExternal });
-  assert.equal((await performer.perform(OPEN)).status, ACTION_RESULT_STATUS.ACCEPTED);
-  assert.equal(
-    (await performer.openSession(WORKSPACE_IDENTITY)).status,
-    ACTION_RESULT_STATUS.ACCEPTED,
-  );
-  assert.deepEqual(
-    node.opens.map((open) => open.kind),
-    [HOST_NODE_OPEN_KIND.ASKED_SESSION, HOST_NODE_OPEN_KIND.ADDRESS],
-  );
-  assert.ok(node.opens.every((open) => open.url === WORKSPACE_LINK));
-});
-
-test("an open refused before the node, or lost at it, is answered without the node opening anything of its own", async () => {
-  const node = recordingOpens();
-  const { performer } = fixture({ openExternal: node.openExternal });
-  const absent = admittedForTest({
-    kind: ACTION_KIND.OPEN,
-    identity: {
-      providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
-      providerSessionId: "workspace-gone",
-    },
-    origin: RUN_ORIGIN.USER,
-  });
-  assert.equal((await performer.perform(absent)).status, ACTION_RESULT_STATUS.UNSUPPORTED);
-  assert.equal(node.opens.length, 0);
-
-  const failing = fixture({
-    openExternal: async () => {
-      throw new Error("no application claims that address");
-    },
-  });
-  assert.equal((await failing.performer.perform(OPEN)).status, ACTION_RESULT_STATUS.REJECTED);
-});
+      const failing = fixture({
+        openExternal: async () => {
+          throw new Error("no application claims that address");
+        },
+      });
+      assert.equal((yield* failing.performer.perform(OPEN)).status, ACTION_RESULT_STATUS.REJECTED);
+    }),
+);

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -4,7 +4,6 @@ import {
   type ActionGuard,
   type CarriedActionResult,
   dispatchByKind,
-  guardedRead,
   type SessionActionKind,
   type ValidatedAction,
 } from "@sidecar/actions";
@@ -29,13 +28,14 @@ import {
 } from "@sidecar/session";
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
+import { Effect } from "effect";
 import {
   HOSTED_ACTION_ANSWER,
   hostedActionResult,
   settleHostedWrite,
 } from "./hosted-action-result.js";
 import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
-import type { AwaitedSettingsStore } from "./settings-store-awaited.js";
+import type { SettingsStore } from "./settings-store.js";
 
 /**
  * An open that was handed to the native node and whose answer was lost with
@@ -44,6 +44,26 @@ import type { AwaitedSettingsStore } from "./settings-store-awaited.js";
  * and never retried.
  */
 export { ExternalOpenAnswerLostError as NodeAnswerLostError };
+
+/**
+ * The guard's own signal as an effect: it answers the moment the standing is
+ * revoked, and is what a read waiting before a provider effect is raced
+ * against, so a turn that ends mid-read settles the action rather than
+ * leaving it waiting on a store.
+ */
+function untilAborted(signal: AbortSignal): Effect.Effect<void> {
+  return Effect.async<void>((resume) => {
+    if (signal.aborted) {
+      resume(Effect.void);
+      return;
+    }
+    const abort = (): void => resume(Effect.void);
+    signal.addEventListener("abort", abort, { once: true });
+    return Effect.sync(() => {
+      signal.removeEventListener("abort", abort);
+    });
+  });
+}
 
 /** What an open answers when its answer was lost: the effect is uncertain. */
 function unknownOpen(error: ExternalOpenAnswerLostError): SessionOpenResult {
@@ -80,14 +100,14 @@ export interface SessionActionPerformerDependencies {
     | "renameWorkspace"
   >;
   /** Pokes a fresh observation pass, so a write that moved a session is seen rather than remembered. */
-  refreshSessions: () => void;
+  refreshSessions: Effect.Effect<void>;
   sendsNetwork: boolean;
-  settingsStore: Pick<AwaitedSettingsStore, "get">;
+  settingsStore: Pick<SettingsStore, "get">;
   rememberWorkspaceDefaults: (
     providerId: CloudAgentProviderId,
     providerProjectId: string,
     selection: WorkspaceAgentSelection | undefined,
-  ) => Promise<void>;
+  ) => Effect.Effect<void>;
   expectCreatedWorkspace: (identity: SessionIdentity, now: number) => void;
   openCreatedWorkspaces: () => void;
   recordProductEvent: RecordProductEvent;
@@ -108,19 +128,19 @@ export interface SessionActionPerformer {
    * The guard is asked once more at the last boundary before a provider
    * effect. A brain-origin action arrives with one; a row press, which is not a
    * write and opens its turn and its effect in the same breath, carries none.
-   * Only a create and a spawn ask it, because only they await a read of their
-   * own — the stored agent defaults — between admission and the write.
+   * Only a create and a spawn ask it, because only they wait on a read of
+   * their own — the stored agent defaults — between admission and the write.
    */
   perform(
     action: ValidatedAction<SessionActionKind>,
     guard?: ActionGuard,
-  ): Promise<CarriedActionResult>;
-  openSession(identity: SessionIdentity): Promise<SessionOpenResult>;
+  ): Effect.Effect<CarriedActionResult>;
+  openSession(identity: SessionIdentity): Effect.Effect<SessionOpenResult>;
   openSessionApplication(
     identity: SessionIdentity,
     applicationId: SessionApplicationId,
-  ): Promise<SessionOpenResult>;
-  openSessionChange(identity: SessionIdentity): Promise<SessionOpenResult>;
+  ): Effect.Effect<SessionOpenResult>;
+  openSessionChange(identity: SessionIdentity): Effect.Effect<SessionOpenResult>;
 }
 
 /** What an open answers when the system refused it: the words a row press and the brain's ask share. */
@@ -167,7 +187,8 @@ export function createSessionActionPerformer(
     providerId: CloudAgentProviderId,
     counted: ProductSessionAction,
     result: Result,
-  ): Result => settleHostedWrite(result, providerId, counted, refreshSessions, recordProductEvent);
+  ): Effect.Effect<Result> =>
+    settleHostedWrite(result, providerId, counted, refreshSessions, recordProductEvent);
 
   /**
    * The session an admitted act names, as the service admits it: only a cloud
@@ -180,15 +201,28 @@ export function createSessionActionPerformer(
       : undefined;
   }
 
-  /** Hands one admitted act on a session to the service, and reads what the provider said. */
-  async function carry(
+  /**
+   * Hands one admitted act on a session to the service, and reads what the
+   * provider said. From the call to the settle the fiber is uninterruptible:
+   * an effect already dispatched is awaited for its result whatever the
+   * standing says, so a write that reached the provider is always the one
+   * that redraws the roster and is counted.
+   */
+  function carry(
     identity: SessionIdentity,
     counted: ProductSessionAction,
     call: (target: HostedActionTarget) => Promise<HostedActionOutcome>,
-  ): Promise<CarriedActionResult> {
-    const target = cloudTarget(identity);
-    if (!target) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_ENDPOINT };
-    return settle(target.providerId, counted, hostedActionResult(await call(target)));
+  ): Effect.Effect<CarriedActionResult> {
+    return Effect.gen(function* () {
+      const target = cloudTarget(identity);
+      if (!target) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_ENDPOINT };
+      return yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const outcome = yield* Effect.promise(() => call(target));
+          return yield* settle(target.providerId, counted, hostedActionResult(outcome));
+        }),
+      );
+    });
   }
 
   const countOpen = (identity: SessionIdentity) => {
@@ -200,7 +234,32 @@ export function createSessionActionPerformer(
     }
   };
 
-  const openAddress = async (
+  /**
+   * Hands one address to the system through the native node: the one answer
+   * both opens read of it, and the count a landed open earns. Uninterruptible
+   * for the same reason a write is — an open already handed to the node is
+   * awaited for its answer, so the open that landed is the one counted.
+   */
+  const openThroughNode = (
+    identity: SessionIdentity,
+    url: string,
+    kind: HostNodeOpenKind,
+    failureReason: string,
+  ): Effect.Effect<SessionOpenResult> =>
+    Effect.tryPromise({ try: () => openExternal(url, kind), catch: (error) => error }).pipe(
+      Effect.as<SessionOpenResult>({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      Effect.tap(() => Effect.sync(() => countOpen(identity))),
+      Effect.catchAll((error) =>
+        Effect.succeed<SessionOpenResult>(
+          error instanceof ExternalOpenAnswerLostError
+            ? unknownOpen(error)
+            : { status: ACTION_RESULT_STATUS.REJECTED, reason: failureReason },
+        ),
+      ),
+      Effect.uninterruptible,
+    );
+
+  const openAddress = (
     identity: SessionIdentity,
     address: (identity: SessionIdentity) => string | undefined,
     // A session that left the roster and one still standing with nowhere to
@@ -208,24 +267,18 @@ export function createSessionActionPerformer(
     absentAddressReason: string,
     failureReason: string,
     kind: HostNodeOpenKind,
-  ): Promise<SessionOpenResult> => {
-    const observed = sessionRegistry.get(identity) !== undefined;
-    const url = observed ? address(identity) : undefined;
-    if (!url) {
-      return {
-        status: ACTION_RESULT_STATUS.UNSUPPORTED,
-        reason: observed ? absentAddressReason : REFUSAL.NO_SESSION,
-      };
-    }
-    try {
-      await openExternal(url, kind);
-    } catch (error) {
-      if (error instanceof ExternalOpenAnswerLostError) return unknownOpen(error);
-      return { status: ACTION_RESULT_STATUS.REJECTED, reason: failureReason };
-    }
-    countOpen(identity);
-    return { status: ACTION_RESULT_STATUS.ACCEPTED };
-  };
+  ): Effect.Effect<SessionOpenResult> =>
+    Effect.suspend(() => {
+      const observed = sessionRegistry.get(identity) !== undefined;
+      const url = observed ? address(identity) : undefined;
+      if (!url) {
+        return Effect.succeed<SessionOpenResult>({
+          status: ACTION_RESULT_STATUS.UNSUPPORTED,
+          reason: observed ? absentAddressReason : REFUSAL.NO_SESSION,
+        });
+      }
+      return openThroughNode(identity, url, kind, failureReason);
+    });
 
   // What a press fires is the address the roster reported, as the service
   // relayed it from the provider's own pass.
@@ -238,36 +291,40 @@ export function createSessionActionPerformer(
       kind,
     );
 
-  const openSessionApplication = async (
+  const openSessionApplication = (
     identity: SessionIdentity,
     applicationId: SessionApplicationId,
     kind: HostNodeOpenKind,
-  ): Promise<SessionOpenResult> => {
-    const session = sessionRegistry.get(identity);
-    if (!session) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_SESSION };
-    const application = session.applications.find((candidate) => candidate.id === applicationId);
-    if (!application) {
-      // The display names travel with the roster the caller already read,
-      // so naming what still opens surfaces nothing the roster withheld.
-      const openable = session.applications.filter((candidate) => candidate.link);
-      return {
-        status: ACTION_RESULT_STATUS.UNSUPPORTED,
-        reason: openable.length
-          ? `That session opens only in ${openable.map((candidate) => candidate.displayName).join(", ")}.`
-          : "That session lists no app to open in.",
-      };
-    }
-    const url = application.link;
-    if (!url) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_APP_ADDRESS };
-    try {
-      await openExternal(url, kind);
-    } catch (error) {
-      if (error instanceof ExternalOpenAnswerLostError) return unknownOpen(error);
-      return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.OPEN_APP_FAILED };
-    }
-    countOpen(identity);
-    return { status: ACTION_RESULT_STATUS.ACCEPTED };
-  };
+  ): Effect.Effect<SessionOpenResult> =>
+    Effect.suspend(() => {
+      const session = sessionRegistry.get(identity);
+      if (!session) {
+        return Effect.succeed<SessionOpenResult>({
+          status: ACTION_RESULT_STATUS.UNSUPPORTED,
+          reason: REFUSAL.NO_SESSION,
+        });
+      }
+      const application = session.applications.find((candidate) => candidate.id === applicationId);
+      if (!application) {
+        // The display names travel with the roster the caller already read,
+        // so naming what still opens surfaces nothing the roster withheld.
+        const openable = session.applications.filter((candidate) => candidate.link);
+        return Effect.succeed<SessionOpenResult>({
+          status: ACTION_RESULT_STATUS.UNSUPPORTED,
+          reason: openable.length
+            ? `That session opens only in ${openable.map((candidate) => candidate.displayName).join(", ")}.`
+            : "That session lists no app to open in.",
+        });
+      }
+      const url = application.link;
+      if (!url) {
+        return Effect.succeed<SessionOpenResult>({
+          status: ACTION_RESULT_STATUS.UNSUPPORTED,
+          reason: REFUSAL.NO_APP_ADDRESS,
+        });
+      }
+      return openThroughNode(identity, url, kind, REFUSAL.OPEN_APP_FAILED);
+    });
 
   // The change is a web page beside the chat, not the chat itself: its row
   // press leaves the panel up, and so does the same open asked of Luke.
@@ -296,118 +353,147 @@ export function createSessionActionPerformer(
 
   /**
    * The stored agent pairing for a provider, read under the turn's guard: the
-   * one read a create and a spawn each await between admission and the write.
+   * one read a create and a spawn each wait on between admission and the
+   * write. The wait is held only as long as the guard's standing — once the
+   * signal fires the read is interrupted and answers nothing, and the
+   * `isRevoked` check that follows it refuses the action before anything is
+   * dispatched. A guard with no signal — a row's own press — waits the read
+   * out. A store that cannot be read is a defect, not a refusal, exactly as
+   * the rejected promise it replaces was.
    */
   const storedSelection = (
     providerId: CloudAgentProviderId,
     guard: ActionGuard | undefined,
-  ): Promise<WorkspaceAgentSelection | undefined> =>
-    guardedRead(settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field), guard).then(
-      (defaults) => defaults?.[providerId],
-    );
+  ): Effect.Effect<WorkspaceAgentSelection | undefined> =>
+    Effect.suspend(() => {
+      const read = Effect.map(
+        Effect.orDie(settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)),
+        (defaults) => defaults?.[providerId],
+      );
+      const signal = guard?.signal;
+      return signal ? Effect.raceFirst(read, Effect.as(untilAborted(signal), undefined)) : read;
+    });
 
   // A new workspace lands only in a project the service's snapshot listed:
   // admission read that list here, and the service admits the ask against
   // the same snapshot before the provider's documented creation endpoint is
   // reached. A fixture run offers no projects at all, so it refuses every ask
   // without touching a network.
-  const createWorkspace = async (
+  const createWorkspace = (
     action: ValidatedAction<typeof ACTION_KIND.CREATE_WORKSPACE>,
     guard: ActionGuard | undefined,
-  ): Promise<CarriedActionResult> => {
-    const { providerId, providerProjectId } = action;
-    if (!sendsNetwork) {
-      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_NETWORK };
-    }
-    if (!isCloudAgentProviderId(providerId)) {
-      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_CREATION };
-    }
-    // A model the user named for this one creation outranks the stored choice
-    // for this action alone; the stored choice stands otherwise. Both are held
-    // to the build's documented table — the named one by admission, the stored
-    // one when it was written — and the service's admission holds whichever
-    // rides to the same table again before anything reaches the provider.
-    const stored = await storedSelection(providerId, guard);
-    if (guard?.isRevoked()) {
-      return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };
-    }
-    const selection = action.agentSelection ?? stored;
-    const outcome = await actions.createWorkspace(providerId, {
-      providerProjectId,
-      agent: action.agent ?? selection?.agent,
-      model: selection?.model,
-      effort: selection?.effort,
-      name: action.name,
-      task: action.task,
+  ): Effect.Effect<CarriedActionResult> =>
+    Effect.gen(function* () {
+      const { providerId, providerProjectId } = action;
+      if (!sendsNetwork) {
+        return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_NETWORK };
+      }
+      if (!isCloudAgentProviderId(providerId)) {
+        return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_CREATION };
+      }
+      // A model the user named for this one creation outranks the stored choice
+      // for this action alone; the stored choice stands otherwise. Both are held
+      // to the build's documented table — the named one by admission, the stored
+      // one when it was written — and the service's admission holds whichever
+      // rides to the same table again before anything reaches the provider.
+      const stored = yield* storedSelection(providerId, guard);
+      if (guard?.isRevoked()) {
+        return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };
+      }
+      const selection = action.agentSelection ?? stored;
+      // From the creation to the remembered default the fiber is
+      // uninterruptible: a workspace the provider made is redrawn, counted,
+      // watched for, and remembered whatever became of the standing that
+      // asked for it.
+      return yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const outcome = yield* Effect.promise(() =>
+            actions.createWorkspace(providerId, {
+              providerProjectId,
+              agent: action.agent ?? selection?.agent,
+              model: selection?.model,
+              effort: selection?.effort,
+              name: action.name,
+              task: action.task,
+            }),
+          );
+          const result = yield* settle(
+            providerId,
+            PRODUCT_SESSION_ACTION.WORKSPACE_CREATE,
+            hostedActionResult(outcome),
+          );
+          if ("failure" in outcome || result.status !== ACTION_RESULT_STATUS.ACCEPTED)
+            return result;
+          // The session the creation named rides out as an identity under the
+          // provider that was asked — an identifier, never an address — for the
+          // envelope to record as the created session.
+          const { providerSessionId } = outcome.answer;
+          const createdSession: SessionIdentity | undefined =
+            providerSessionId === undefined ? undefined : { providerId, providerSessionId };
+          if (createdSession) {
+            // A workspace that landed is also one the developer just asked to be
+            // taken to, so the session the creation response named waits here for
+            // observation to report it, and is opened then like a pressed row.
+            // Noted before the refresh the settle began can commit, so the very pass
+            // that first sees the session resolves it; a pass that already committed
+            // it is claimed against here, and later commits carry every later arrival.
+            expectCreatedWorkspace(createdSession, Date.now());
+            openCreatedWorkspaces();
+          }
+          // The first workspace that actually lands chooses the default provider,
+          // so a later ask that names none has somewhere unsurprising to go. Only
+          // while nothing is chosen: a default the user holds is theirs to change,
+          // never a creation's. Deterministic on the validated action — nothing a
+          // model composed decides this — and losing the save loses only the
+          // remembered default, never the workspace that just landed.
+          yield* rememberWorkspaceDefaults(providerId, providerProjectId, action.agentSelection);
+          return {
+            status: ACTION_RESULT_STATUS.ACCEPTED,
+            ...(createdSession ? { createdSession } : undefined),
+          };
+        }),
+      );
     });
-    const result = settle(
-      providerId,
-      PRODUCT_SESSION_ACTION.WORKSPACE_CREATE,
-      hostedActionResult(outcome),
-    );
-    if ("failure" in outcome || result.status !== ACTION_RESULT_STATUS.ACCEPTED) return result;
-    // The session the creation named rides out as an identity under the
-    // provider that was asked — an identifier, never an address — for the
-    // envelope to record as the created session.
-    const { providerSessionId } = outcome.answer;
-    const createdSession: SessionIdentity | undefined =
-      providerSessionId === undefined ? undefined : { providerId, providerSessionId };
-    if (createdSession) {
-      // A workspace that landed is also one the developer just asked to be
-      // taken to, so the session the creation response named waits here for
-      // observation to report it, and is opened then like a pressed row.
-      // Noted before the refresh the settle began can commit, so the very pass
-      // that first sees the session resolves it; a pass that already committed
-      // it is claimed against here, and later commits carry every later arrival.
-      expectCreatedWorkspace(createdSession, Date.now());
-      openCreatedWorkspaces();
-    }
-    // The first workspace that actually lands chooses the default provider,
-    // so a later ask that names none has somewhere unsurprising to go. Only
-    // while nothing is chosen: a default the user holds is theirs to change,
-    // never a creation's. Deterministic on the validated action — nothing a
-    // model composed decides this — and losing the save loses only the
-    // remembered default, never the workspace that just landed.
-    await rememberWorkspaceDefaults(providerId, providerProjectId, action.agentSelection);
-    return {
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      ...(createdSession ? { createdSession } : undefined),
-    };
-  };
 
   // Another agent in an observed workspace: the agent kind the action carries
   // is the one that session's own observation listed, and the service reads
   // the workspace it lands in back from its stored snapshot.
-  const addWorkspaceAgent = async (
+  const addWorkspaceAgent = (
     action: ValidatedAction<typeof ACTION_KIND.ADD_AGENT>,
     guard: ActionGuard | undefined,
-  ): Promise<CarriedActionResult> => {
-    const target = cloudTarget(action.identity);
-    if (!target) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_ENDPOINT };
-    const stored = await storedSelection(target.providerId, guard);
-    if (guard?.isRevoked()) {
-      return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };
-    }
-    // A stored pairing rides along only when it names the very agent kind the
-    // developer asked for, and a model the ask named brings its own effort or
-    // none: a preference rides with an ask, never against it.
-    const paired = stored?.agent === action.agent ? stored : undefined;
-    const model = action.model ?? paired?.model;
-    const effort = action.model === undefined ? paired?.effort : action.effort;
-    return settle(
-      target.providerId,
-      PRODUCT_SESSION_ACTION.AGENT_ADD,
-      hostedActionResult(
-        await actions.addAgent(target, {
-          agent: action.agent,
-          model,
-          effort,
-          name: action.name,
-          task: action.task,
+  ): Effect.Effect<CarriedActionResult> =>
+    Effect.gen(function* () {
+      const target = cloudTarget(action.identity);
+      if (!target) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_ENDPOINT };
+      const stored = yield* storedSelection(target.providerId, guard);
+      if (guard?.isRevoked()) {
+        return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };
+      }
+      // A stored pairing rides along only when it names the very agent kind the
+      // developer asked for, and a model the ask named brings its own effort or
+      // none: a preference rides with an ask, never against it.
+      const paired = stored?.agent === action.agent ? stored : undefined;
+      const model = action.model ?? paired?.model;
+      const effort = action.model === undefined ? paired?.effort : action.effort;
+      return yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const outcome = yield* Effect.promise(() =>
+            actions.addAgent(target, {
+              agent: action.agent,
+              model,
+              effort,
+              name: action.name,
+              task: action.task,
+            }),
+          );
+          return yield* settle(
+            target.providerId,
+            PRODUCT_SESSION_ACTION.AGENT_ADD,
+            hostedActionResult(outcome),
+          );
         }),
-      ),
-    );
-  };
+      );
+    });
 
   // The two renames carry the session and the name, never the target: the
   // service resolves the workspace or the session from its stored snapshot.
@@ -421,19 +507,19 @@ export function createSessionActionPerformer(
       actions.renameSession(target, action.name),
     );
 
-  // Of the actions below, only the create and the spawn await anything of their
-  // own between admission and the provider effect, so only they take the
+  // Of the actions below, only the create and the spawn wait on anything of
+  // their own between admission and the provider effect, so only they take the
   // guard; the rest reach the service with nothing awaited between.
   const performSessionAction = (
     action: ValidatedAction<SessionActionKind>,
     guard: ActionGuard | undefined,
-  ): Promise<CarriedActionResult> =>
+  ): Effect.Effect<CarriedActionResult> =>
     dispatchByKind(action, {
       [ACTION_KIND.MESSAGE]: sendMessage,
       [ACTION_KIND.CONTROL]: executeControl,
       // An open the brain carries was asked of Luke, never pressed on a row,
       // so the node is told a panel still stands over the chat coming forward.
-      [ACTION_KIND.OPEN]: async (open): Promise<CarriedActionResult> =>
+      [ACTION_KIND.OPEN]: (open): Effect.Effect<CarriedActionResult> =>
         open.applicationId
           ? openSessionApplication(
               open.identity,

--- a/packages/host/src/session-row-actions.test.ts
+++ b/packages/host/src/session-row-actions.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { ACTION_REFUSAL } from "@sidecar/actions";
 import {
   PRODUCT_EVENT,
@@ -19,7 +20,7 @@ import {
   type Session,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
-import { test } from "vitest";
+import { Effect, Fiber } from "effect";
 import { createSessionRowActions } from "./session-row-actions.js";
 
 /*
@@ -72,9 +73,9 @@ function fixture(outcome: HostedActionOutcome, drawn: readonly Session[] = [CLOU
         return outcome;
       },
     },
-    refresh: async () => {
+    refresh: Effect.sync(() => {
       recorded.refreshes += 1;
-    },
+    }),
     recordProductEvent: (name, properties) => {
       recorded.events.push({ name, properties });
     },
@@ -87,96 +88,143 @@ const identityOf = (session: Session) => ({
   providerSessionId: session.providerSessionId,
 });
 
-test("a session the drawn roster does not hold is refused without a call", async () => {
-  const { actions, recorded } = fixture({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
-  const result = await actions.sendMessage(
-    { providerId: CLOUD.providerId, providerSessionId: "chat-nobody-drew" },
-    "hello",
-  );
-  assert.deepEqual(result, {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: ACTION_REFUSAL.NO_SESSION,
-  });
-  assert.equal(recorded.calls.length, 0);
-  assert.equal(recorded.refreshes, 0);
-});
+it.effect("a session the drawn roster does not hold is refused without a call", () =>
+  Effect.gen(function* () {
+    const { actions, recorded } = fixture({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+    const result = yield* actions.sendMessage(
+      { providerId: CLOUD.providerId, providerSessionId: "chat-nobody-drew" },
+      "hello",
+    );
+    assert.deepEqual(result, {
+      status: ACTION_RESULT_STATUS.REJECTED,
+      reason: ACTION_REFUSAL.NO_SESSION,
+    });
+    assert.equal(recorded.calls.length, 0);
+    assert.equal(recorded.refreshes, 0);
+  }),
+);
 
-test("a session whose provider has no endpoint from this Mac is unsupported without a call", async () => {
-  const { actions, recorded } = fixture({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
-  const result = await actions.executeControl(identityOf(LOCAL), "cancel-run");
-  assert.equal(result.status, ACTION_RESULT_STATUS.UNSUPPORTED);
-  assert.equal(recorded.calls.length, 0);
-});
+it.effect(
+  "a session whose provider has no endpoint from this Mac is unsupported without a call",
+  () =>
+    Effect.gen(function* () {
+      const { actions, recorded } = fixture({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+      const result = yield* actions.executeControl(identityOf(LOCAL), "cancel-run");
+      assert.equal(result.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+      assert.equal(recorded.calls.length, 0);
+    }),
+);
 
-test("an accepted write names the drawn session, redraws the rows, and is counted once", async () => {
-  const { actions, recorded } = fixture({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+it.effect("an accepted write names the drawn session, redraws the rows, and is counted once", () =>
+  Effect.gen(function* () {
+    const { actions, recorded } = fixture({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
 
-  assert.deepEqual(await actions.sendMessage(identityOf(CLOUD), "ship it"), {
-    status: ACTION_RESULT_STATUS.ACCEPTED,
-  });
-  assert.deepEqual(await actions.executeControl(identityOf(CLOUD), "cancel-run"), {
-    status: ACTION_RESULT_STATUS.ACCEPTED,
-  });
+    assert.deepEqual(yield* actions.sendMessage(identityOf(CLOUD), "ship it"), {
+      status: ACTION_RESULT_STATUS.ACCEPTED,
+    });
+    assert.deepEqual(yield* actions.executeControl(identityOf(CLOUD), "cancel-run"), {
+      status: ACTION_RESULT_STATUS.ACCEPTED,
+    });
 
-  assert.deepEqual(recorded.calls, [
-    { target: identityOf(CLOUD), ask: "ship it" },
-    { target: identityOf(CLOUD), ask: "cancel-run" },
-  ]);
-  assert.equal(recorded.refreshes, 2);
-  assert.deepEqual(recorded.events, [
-    {
-      name: PRODUCT_EVENT.SESSION_ACTION_SEND,
-      properties: {
-        provider_id: CLOUD.providerId,
-        session_action: PRODUCT_SESSION_ACTION.MESSAGE_SEND,
+    assert.deepEqual(recorded.calls, [
+      { target: identityOf(CLOUD), ask: "ship it" },
+      { target: identityOf(CLOUD), ask: "cancel-run" },
+    ]);
+    assert.equal(recorded.refreshes, 2);
+    assert.deepEqual(recorded.events, [
+      {
+        name: PRODUCT_EVENT.SESSION_ACTION_SEND,
+        properties: {
+          provider_id: CLOUD.providerId,
+          session_action: PRODUCT_SESSION_ACTION.MESSAGE_SEND,
+        },
       },
-    },
-    {
-      name: PRODUCT_EVENT.SESSION_ACTION_SEND,
-      properties: {
-        provider_id: CLOUD.providerId,
-        session_action: PRODUCT_SESSION_ACTION.CONTROL_RUN,
+      {
+        name: PRODUCT_EVENT.SESSION_ACTION_SEND,
+        properties: {
+          provider_id: CLOUD.providerId,
+          session_action: PRODUCT_SESSION_ACTION.CONTROL_RUN,
+        },
       },
-    },
-  ]);
-});
+    ]);
+  }),
+);
 
-test("the service's refusal reaches the row as written, redraws, and is not counted", async () => {
-  const { actions, recorded } = fixture({
-    answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." },
-  });
-  assert.deepEqual(await actions.executeControl(identityOf(CLOUD), "cancel-run"), {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: "That run has ended.",
-  });
-  assert.equal(recorded.refreshes, 1);
-  assert.equal(recorded.events.length, 0);
-});
+it.effect("the service's refusal reaches the row as written, redraws, and is not counted", () =>
+  Effect.gen(function* () {
+    const { actions, recorded } = fixture({
+      answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." },
+    });
+    assert.deepEqual(yield* actions.executeControl(identityOf(CLOUD), "cancel-run"), {
+      status: ACTION_RESULT_STATUS.REJECTED,
+      reason: "That run has ended.",
+    });
+    assert.equal(recorded.refreshes, 1);
+    assert.equal(recorded.events.length, 0);
+  }),
+);
 
-test("a call that never left is a refusal, and one that lost its answer is unknown", async () => {
-  const unsent = fixture({ failure: HOSTED_ACTION_FAILURE.NOT_SENT });
-  assert.equal(
-    (await unsent.actions.sendMessage(identityOf(CLOUD), "hello")).status,
-    ACTION_RESULT_STATUS.REJECTED,
-  );
+it.effect("a call that never left is a refusal, and one that lost its answer is unknown", () =>
+  Effect.gen(function* () {
+    const unsent = fixture({ failure: HOSTED_ACTION_FAILURE.NOT_SENT });
+    assert.equal(
+      (yield* unsent.actions.sendMessage(identityOf(CLOUD), "hello")).status,
+      ACTION_RESULT_STATUS.REJECTED,
+    );
 
-  const refused = fixture({ failure: HOSTED_ACTION_FAILURE.REFUSED });
-  assert.equal(
-    (await refused.actions.sendMessage(identityOf(CLOUD), "hello")).status,
-    ACTION_RESULT_STATUS.REJECTED,
-  );
+    const refused = fixture({ failure: HOSTED_ACTION_FAILURE.REFUSED });
+    assert.equal(
+      (yield* refused.actions.sendMessage(identityOf(CLOUD), "hello")).status,
+      ACTION_RESULT_STATUS.REJECTED,
+    );
 
-  const lost = fixture({ failure: HOSTED_ACTION_FAILURE.LOST });
-  assert.equal(
-    (await lost.actions.sendMessage(identityOf(CLOUD), "hello")).status,
-    UNKNOWN_ACTION_STATUS,
-  );
+    const lost = fixture({ failure: HOSTED_ACTION_FAILURE.LOST });
+    assert.equal(
+      (yield* lost.actions.sendMessage(identityOf(CLOUD), "hello")).status,
+      UNKNOWN_ACTION_STATUS,
+    );
 
-  const unreadable = fixture({ failure: HOSTED_ACTION_FAILURE.UNREADABLE });
-  assert.equal(
-    (await unreadable.actions.executeControl(identityOf(CLOUD), "cancel-run")).status,
-    UNKNOWN_ACTION_STATUS,
-  );
-  assert.equal(unreadable.recorded.refreshes, 1);
-  assert.equal(unreadable.recorded.events.length, 0);
-});
+    const unreadable = fixture({ failure: HOSTED_ACTION_FAILURE.UNREADABLE });
+    assert.equal(
+      (yield* unreadable.actions.executeControl(identityOf(CLOUD), "cancel-run")).status,
+      UNKNOWN_ACTION_STATUS,
+    );
+    assert.equal(unreadable.recorded.refreshes, 1);
+    assert.equal(unreadable.recorded.events.length, 0);
+  }),
+);
+
+it.effect("a write the service already carried settles though its caller is interrupted", () =>
+  Effect.gen(function* () {
+    const recorded = { refreshes: 0, events: 0 };
+    let release: (() => void) | undefined;
+    const actions = createSessionRowActions({
+      drawn: () => [CLOUD, LOCAL],
+      client: {
+        sendMessage: () =>
+          new Promise<HostedActionOutcome>((resolve) => {
+            release = () => resolve({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+          }),
+        executeControl: async () => ({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } }),
+      },
+      refresh: Effect.sync(() => {
+        recorded.refreshes += 1;
+      }),
+      recordProductEvent: () => {
+        recorded.events += 1;
+      },
+    });
+
+    const writing = yield* Effect.fork(actions.sendMessage(identityOf(CLOUD), "ship it"));
+    for (let tick = 0; tick < 100 && release === undefined; tick += 1) yield* Effect.yieldNow();
+    assert.ok(release, "the write reached the service");
+    // The caller ends under the write; the answer the service is still
+    // holding is read out all the same, and what it earns is not dropped.
+    const interrupting = yield* Effect.fork(Fiber.interrupt(writing));
+    release();
+    yield* Fiber.join(interrupting);
+
+    assert.equal(recorded.refreshes, 1);
+    assert.equal(recorded.events, 1);
+  }),
+);

--- a/packages/host/src/session-row-actions.ts
+++ b/packages/host/src/session-row-actions.ts
@@ -13,6 +13,7 @@ import {
   sessionWithIdentity,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { Effect } from "effect";
 import {
   HOSTED_ACTION_ANSWER,
   hostedActionResult,
@@ -32,7 +33,7 @@ export interface SessionRowActionsDependencies {
   drawn: () => readonly Session[];
   client: Pick<HostedActionClient, "sendMessage" | "executeControl">;
   /** Pokes a fresh observation pass, so a write that moved a session is seen rather than remembered. */
-  refresh: () => void;
+  refresh: Effect.Effect<void>;
   recordProductEvent: RecordProductEvent;
 }
 
@@ -49,8 +50,8 @@ export interface SessionRowActionsDependencies {
  * user's own act and what became of it belongs beside the field it left.
  */
 export interface SessionRowActions {
-  sendMessage(identity: SessionIdentity, text: string): Promise<SessionWriteResult>;
-  executeControl(identity: SessionIdentity, controlId: string): Promise<SessionWriteResult>;
+  sendMessage(identity: SessionIdentity, text: string): Effect.Effect<SessionWriteResult>;
+  executeControl(identity: SessionIdentity, controlId: string): Effect.Effect<SessionWriteResult>;
 }
 
 export function createSessionRowActions(
@@ -58,26 +59,41 @@ export function createSessionRowActions(
 ): SessionRowActions {
   const { drawn, client, refresh, recordProductEvent } = dependencies;
 
-  const carry = async (
+  const carry = (
     identity: SessionIdentity,
     counted: ProductSessionAction,
     call: (target: HostedActionTarget) => Promise<HostedActionOutcome>,
-  ): Promise<SessionWriteResult> => {
-    const session = sessionWithIdentity(identity, drawn());
-    if (!session)
-      return { status: ACTION_RESULT_STATUS.REJECTED, reason: ACTION_REFUSAL.NO_SESSION };
-    const providerId = session.providerId;
-    if (!isCloudAgentProviderId(providerId)) {
-      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: HOSTED_ACTION_ANSWER.NO_ENDPOINT };
-    }
-    return settleHostedWrite(
-      hostedActionResult(await call({ providerId, providerSessionId: session.providerSessionId })),
-      providerId,
-      counted,
-      refresh,
-      recordProductEvent,
-    );
-  };
+  ): Effect.Effect<SessionWriteResult> =>
+    Effect.gen(function* () {
+      const session = sessionWithIdentity(identity, drawn());
+      if (!session)
+        return { status: ACTION_RESULT_STATUS.REJECTED, reason: ACTION_REFUSAL.NO_SESSION };
+      const providerId = session.providerId;
+      if (!isCloudAgentProviderId(providerId)) {
+        return {
+          status: ACTION_RESULT_STATUS.UNSUPPORTED,
+          reason: HOSTED_ACTION_ANSWER.NO_ENDPOINT,
+        };
+      }
+      // From the call to the settle the fiber is uninterruptible: a write the
+      // service already carried to the provider may have landed, so the
+      // redraw it earns and the count it earns are never dropped by a
+      // request fiber ending under them.
+      return yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const outcome = yield* Effect.promise(() =>
+            call({ providerId, providerSessionId: session.providerSessionId }),
+          );
+          return yield* settleHostedWrite(
+            hostedActionResult(outcome),
+            providerId,
+            counted,
+            refresh,
+            recordProductEvent,
+          );
+        }),
+      );
+    });
 
   return {
     sendMessage: (identity, text) =>

--- a/packages/host/src/settings-store-awaited.ts
+++ b/packages/host/src/settings-store-awaited.ts
@@ -27,12 +27,10 @@ import type { SettingsStore, StoredAccount } from "./settings-store.js";
  * caller yields.
  *
  * @deprecated The strangler shim on the `docs/adr/0001-effect.md` allowlist,
- * standing in for the two callers still promise-shaped: `compose-calendars.ts`'s
- * `GoogleCalendarReader`/`AppleCalendarReader` readers, and the type this
- * interface still names for `session-action-performer.ts`'s one field read
- * (`Pick<AwaitedSettingsStore, "get">`), even though that read no longer runs
- * on this file's own instance. It is deleted by P12-14i once both move onto
- * the store itself.
+ * standing in for the one caller still promise-shaped: `compose-calendars.ts`'s
+ * `GoogleCalendarReader`/`AppleCalendarReader` readers. The session action
+ * performer left in P12-15e and reads `Pick<SettingsStore, "get">`. It is
+ * deleted by P12-14i once that caller moves onto the store itself.
  */
 export interface AwaitedSettingsStore {
   get<Field extends AppSettingField>(field: Field): Promise<AppSettingValue<Field>>;


### PR DESCRIPTION
P12-15e — the session action performer and hosted write settle as effects.

`SessionActionPerformer.perform`, its three opens, `SessionRowActions`'
two writes, and `settleHostedWrite` answer `Effect`s now, run on the fiber
that already carries the action: the brain's tool fiber (#1234/#1279) or the
Gateway request fiber (#1220). The observation refresh a landed write earns is
a `yield*` of `composeObservation`'s own `pokeRefresh`, which is
`Effect.forkDaemon` of `loop.refresh` — a poke and never a wait, exactly as
the detached run it replaces — so that composer's `Runtime.runFork` row is
gone from the ADR paragraph, and with it the two runs P12-14f left for this
performer: it takes `Pick<SettingsStore, "get">` (#1270) and the remembering
effect itself.

From the moment an effect is dispatched — the service call, the node's open —
to its settle the fiber is `Effect.uninterruptible`: under the `Effect.promise`
wrap this PR removes, an interrupted caller abandoned the wait while the
promise ran on and settled, and on the fiber interruption would drop the poke
and the count for a write that had already reached the provider (caught by
Bugbot). Root AGENTS.md already states that rule — an effect already
dispatched is awaited for its result whatever the signal says — and a test
that fails without the mask pins it.

Nothing about admission, an action's payload, or the roster check changes: a
write still reaches a provider only through what `admit()` minted, and the
23 actions goldens are untouched.

### What the plan did not settle, decided here

- **The brain's carrier.** `BrainActionPerformer.carry` is still a promise
  (P12-15d's row), so the host's carrier is handed a `carry` dependency and
  `composeBrain` — already on the handed-runtime allowlist for
  `refreshSessions` — runs the performer's effect on the same `execution`
  runtime. No new allowlist row; the existing `compose-brain.ts` paragraph
  names both runs and when each goes. **P12-15d:** delete this `carry`
  dependency when `BrainActionPerformer.carry` answers an effect.
- **The desktop's act rows.** `apps/desktop/src/main/ipc/session-acts.ts`
  borrowed `SessionActionPerformer`/`SessionRowActions` for their shape but is
  fed by the Gateway client's promises, so it declares those two promise-shaped
  collaborators itself rather than dragging the act router onto effects.
- **The guard'd read.** `guardedRead`'s promise race became a local
  `untilAborted(signal)` raced against the store read; a guard with no signal
  waits the read out, as before. `guardedRead` itself is untouched for
  `admit.ts` (P12-15d's).

No further slices: the row converts whole in this PR.

### Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green locally (Linux). No renderer or UI change (the desktop edit is main-process typing), and `verify.sh` needs macOS, which this workspace is not; per CLAUDE.md CI builds nothing for the Mac.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture diff.
- [x] Gateway envelope goldens unchanged. — untouched; the five session Gateway methods yield the same answers, only without an `Effect.promise` wrap.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — the one cast added is in a test fixture (`SettingsStore["get"]`, replacing the same cast on `AwaitedSettingsStore["get"]`).
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — one run added, in `compose-brain.ts`, already a `runOnHandedRuntime` entry; one run deleted (`compose-observation.ts`'s `pokeRefresh` fork, and the two P12-14f runs for this performer). `effect-edges.json` needs no row change: both files keep other runs.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none; `untilAborted` reads a signal the caller owns.
- [x] Test count equals the pre-PR count or the delta is listed. — `@sidecar/host` 343 → 344 (+1: the interrupted-write test in `session-row-actions.test.ts`), `@luke/desktop` 517 → 517.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced; `AwaitedSettingsStore`'s `@deprecated` note drops this performer from the callers it stands in for (P12-14i now has one caller left).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no doc sentence names these parts; root/package pairs untouched and byte-identical. `docs/adr/0001-effect.md`'s three paragraphs for these runs are rewritten in place.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/host` already declares `effect`; no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — no new imports behind a door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
