### PR TITLE
refactor(actions): admitEffect is the one gauntlet and the promise door is deleted

### DIFF
--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -25,7 +25,7 @@ export interface SessionActsDependencies {
     openSessionChange(identity: SessionIdentity): Promise<SessionOpenResult>;
   };
   /**
-   * The two writes a row asks for, carried to the host, whose `admit()`
+   * The two writes a row asks for, carried to the host, whose `admitEffect()`
    * decides each against the roster it reads for itself; nothing here decides
    * whether a session takes them.
    */

--- a/apps/desktop/src/shared/messages/acts.ts
+++ b/apps/desktop/src/shared/messages/acts.ts
@@ -104,7 +104,7 @@ export const ACT_KIND = {
   /**
    * The two writes a session's own row mints — the follow-up typed into its
    * composer and the press of a control its provider advertised — carried to
-   * the host, where `admit()` decides them against the roster it reads for
+   * the host, where `admitEffect()` decides them against the roster it reads for
    * itself before any provider sees them.
    */
   SESSION_SEND_MESSAGE: "session.sendMessage",

--- a/apps/web/server/hosted/action-execute.ts
+++ b/apps/web/server/hosted/action-execute.ts
@@ -8,7 +8,8 @@ import {
   type ActionRequest,
   type ActionResultStatus,
   type AdmitContext,
-  admit,
+  type AdmitRefusal,
+  admitEffect,
   CLOUD_AGENT_PROVIDER_ID,
   type CloudAgentProviderId,
   dispatchAction,
@@ -18,6 +19,8 @@ import {
   type HostedConversationMessage,
   HTTP_STATUS,
   normalizeSession,
+  type PluginActionKind,
+  type PluginActionRequests,
   PROVIDER_IDENTITY_BY_ID,
   type ProviderActionResult,
   type ProviderSessionObservation,
@@ -28,7 +31,6 @@ import {
   providerWorkspaceAgentRequest,
   providerWorkspaceRenameRequest,
   providerWorkspaceRequest,
-  type Refusal,
   RUN_ORIGIN,
   type SessionActionKind,
   type SessionProviderPlugin,
@@ -323,7 +325,7 @@ function missingTargetPhrase(reason: string): string | undefined {
 function fromRefusal(
   providerId: CloudAgentProviderId,
   pass: Pick<ActionRoster, "unauthorized" | "unreachable">,
-  refusal: Refusal,
+  refusal: AdmitRefusal,
 ): ActionExecutionAnswer {
   const missing = missingTargetPhrase(refusal.reason);
   return {
@@ -333,16 +335,17 @@ function fromRefusal(
 }
 
 /**
- * One action a remote client asked, admitted and carried. The build's own
- * capability map answers first; then `admit()` reads the roster the action
- * stands on for itself — the stored snapshot's slice for this provider, the
- * session or the project it names, the advertisement it stands on, the
- * bounds on the developer's own words — and only the validated action it
- * mints reaches the adapter, which builds each effect's route back out of
- * the same roster. No pass runs here: the snapshot is what the user was
- * shown, and the provider answers for whether the target still stands.
+ * One action a remote client asked, admitted and carried, as the effect the
+ * caller composes into its own. The build's own capability map answers first;
+ * then `admitEffect()` reads the roster the action stands on for itself — the
+ * stored snapshot's slice for this provider, the session or the project it
+ * names, the advertisement it stands on, the bounds on the developer's own
+ * words — and only the validated action it mints reaches the adapter, which
+ * builds each effect's route back out of the same roster. No pass runs here:
+ * the snapshot is what the user was shown, and the provider answers for
+ * whether the target still stands.
  */
-export async function executeSessionAction(options: {
+export function executeSessionAction(options: {
   kind: HostedSessionActionKind;
   providerId: CloudAgentProviderId;
   /** The ask's own fields, keyed by the names admission reads, unparsed. */
@@ -350,37 +353,48 @@ export async function executeSessionAction(options: {
   apiKey: string;
   roster: ActionRoster;
   seams?: ActionExecuteSeams;
-}): Promise<ActionExecutionAnswer> {
-  const { kind, providerId, fields, apiKey, roster } = options;
-  const unsupported = actionUnsupportedReason(kind, providerId);
-  if (unsupported) return { result: ACTION_RESULT_STATUS.UNSUPPORTED, reason: unsupported };
+}): Effect.Effect<ActionExecutionAnswer> {
+  return Effect.suspend(() => {
+    const { kind, providerId, fields, apiKey, roster } = options;
+    const unsupported = actionUnsupportedReason(kind, providerId);
+    if (unsupported) {
+      return Effect.succeed<ActionExecutionAnswer>({
+        result: ACTION_RESULT_STATUS.UNSUPPORTED,
+        reason: unsupported,
+      });
+    }
 
-  const plugin = pluginOverRoster(providerId, apiKey, roster, options.seams ?? {});
-  const request: ActionRequest<HostedSessionActionKind> = { kind, fields };
-  const admitted = await admit(request, admissionOver(plugin, roster));
-  if (admitted.kind === undefined) return fromRefusal(providerId, roster, admitted);
+    const plugin = pluginOverRoster(providerId, apiKey, roster, options.seams ?? {});
+    const request: ActionRequest<HostedSessionActionKind> = { kind, fields };
+    const carried = <Kind extends PluginActionKind>(
+      name: Kind,
+      ask: PluginActionRequests[Kind],
+    ): Effect.Effect<ActionExecutionAnswer> =>
+      Effect.map(
+        Effect.promise(() => dispatchAction(plugin, name, ask)),
+        fromProviderResult,
+      );
 
-  return dispatchByKind(admitted, {
-    [ACTION_KIND.MESSAGE]: async (action) =>
-      fromProviderResult(await dispatchAction(plugin, "message", providerSessionMessage(action))),
-    [ACTION_KIND.CONTROL]: async (action) =>
-      fromProviderResult(await dispatchAction(plugin, "control", providerControlRequest(action))),
-    [ACTION_KIND.ADD_AGENT]: async (action) =>
-      fromProviderResult(
-        await dispatchAction(plugin, "spawnAgent", providerWorkspaceAgentRequest(action)),
+    return admitEffect(request, admissionOver(plugin, roster)).pipe(
+      Effect.flatMap(
+        (admitted): Effect.Effect<ActionExecutionAnswer> =>
+          dispatchByKind(admitted, {
+            [ACTION_KIND.MESSAGE]: (action) => carried("message", providerSessionMessage(action)),
+            [ACTION_KIND.CONTROL]: (action) => carried("control", providerControlRequest(action)),
+            [ACTION_KIND.ADD_AGENT]: (action) =>
+              carried("spawnAgent", providerWorkspaceAgentRequest(action)),
+            [ACTION_KIND.RENAME_SESSION]: (action) =>
+              carried("renameSession", providerSessionRenameRequest(action)),
+            [ACTION_KIND.RENAME_WORKSPACE]: (action) =>
+              carried("renameWorkspace", providerWorkspaceRenameRequest(action)),
+            [ACTION_KIND.CREATE_WORKSPACE]: (action) =>
+              carried("createWorkspace", providerWorkspaceRequest(action)),
+          }),
       ),
-    [ACTION_KIND.RENAME_SESSION]: async (action) =>
-      fromProviderResult(
-        await dispatchAction(plugin, "renameSession", providerSessionRenameRequest(action)),
+      Effect.catchTag("AdmitRefusal", (refusal) =>
+        Effect.succeed(fromRefusal(providerId, roster, refusal)),
       ),
-    [ACTION_KIND.RENAME_WORKSPACE]: async (action) =>
-      fromProviderResult(
-        await dispatchAction(plugin, "renameWorkspace", providerWorkspaceRenameRequest(action)),
-      ),
-    [ACTION_KIND.CREATE_WORKSPACE]: async (action) =>
-      fromProviderResult(
-        await dispatchAction(plugin, "createWorkspace", providerWorkspaceRequest(action)),
-      ),
+    );
   });
 }
 

--- a/apps/web/server/hosted/action-session.ts
+++ b/apps/web/server/hosted/action-session.ts
@@ -77,7 +77,7 @@ function aimed(
  * reads, and the one place that says which actions name a session at all — the
  * creation names a project instead. Nothing here validates a value: it is
  * renamed and handed on unparsed, because whether it is a message, a name, a
- * task, or a model any session or project actually takes is `admit()`'s
+ * task, or a model any session or project actually takes is `admitEffect()`'s
  * question, asked once, against the stored snapshot the action stands on.
  */
 const HOSTED_ACTION_FIELDS = {
@@ -253,7 +253,7 @@ export async function handleSessionAction(options: SessionActionOptions): Promis
   if (key instanceof Response) return key;
 
   const roster = await options.roster(userId, providerId, secret);
-  const execute = options.execute ?? executeSessionAction;
+  const execute = options.execute ?? routeExecute;
   return actionAnswer(await execute({ kind, providerId, fields, apiKey: key.apiKey, roster }));
 }
 
@@ -275,6 +275,15 @@ function routeRoster(route: HostedVaultRoute): SessionActionOptions["roster"] {
       }),
     );
 }
+
+/**
+ * The execution a deployed route carries an admitted action through. It is an
+ * effect, and this is where a deployed route runs it: on the same edge
+ * runtime {@link routeRoster} reads the snapshot on, since the handler above
+ * answers a `Response` and holds no fiber of its own.
+ */
+const routeExecute: NonNullable<SessionActionOptions["execute"]> = (options) =>
+  runWeb(executeSessionAction(options));
 
 /** The six actions, each as the one thing its route names. */
 export const handleMessageAction = (route: HostedVaultRoute): Promise<Response> =>

--- a/apps/web/server/hosted/brain-host/performer.ts
+++ b/apps/web/server/hosted/brain-host/performer.ts
@@ -37,10 +37,10 @@ import type { HostedRoster } from "./roster.js";
 
 /**
  * The host's half of the gauntlet every action the hosted brain asks for
- * runs. The action tool's own `execute` admits the call by `admit`, against
- * the roster it reads for itself through the readers handed out here — the
- * stored snapshot, the projects that snapshot listed, the developer's saved
- * defaults, the facts Luke remembers — and only the validated action it
+ * runs. The action tool's own `execute` admits the call by `admitEffect`,
+ * against the roster it reads for itself through the readers handed out here
+ * — the stored snapshot, the projects that snapshot listed, the developer's
+ * saved defaults, the facts Luke remembers — and only the validated action it
  * mints reaches the carrier below. The carrier reaches the facts table for
  * a memory and the cloud action execution for a session or a workspace,
  * which admits the action once more against a fresh pass before the
@@ -65,7 +65,7 @@ export type CloudActionExecutor = (input: {
   apiKey: string;
   /** The provider's slice of the stored roster, which the execution admits the action against again. */
   roster: ActionRoster;
-}) => Promise<ActionExecutionAnswer>;
+}) => Effect.Effect<ActionExecutionAnswer>;
 
 export interface HostedCarrierDependencies {
   /** The roster as the snapshot holds it now, read again for every action. */
@@ -88,13 +88,13 @@ const REFUSAL = {
 /** What the hosted carrier answers with, for the action tools' context. */
 export interface HostedActionCarrier {
   /** The readers admission consults for one call; the roster is read once per call however many readers ask. */
-  admission(): Promise<ActionAdmissionReads>;
+  admission(): Effect.Effect<ActionAdmissionReads>;
   /** Carries an action admission minted, with the call's own fields for the execution that admits it again. */
   carry(
     action: ValidatedAction,
     fields: WireRecord,
     standing: ToolContext,
-  ): Promise<ActionOutputEnvelope>;
+  ): Effect.Effect<ActionOutputEnvelope>;
 }
 
 function carriedResult(executed: ActionExecutionAnswer): CarriedActionResult {
@@ -121,75 +121,92 @@ function storedRosterOf(roster: HostedRoster): { roster?: ObservedRoster } {
 }
 
 export function hostedActionCarrier(dependencies: HostedCarrierDependencies): HostedActionCarrier {
-  const carrySessionAction = async (
+  const carrySessionAction = (
     action: ValidatedAction<SessionActionKind>,
     fields: WireRecord,
     standing: ToolContext,
-  ): Promise<ActionOutputEnvelope> => {
-    const roster = await dependencies.roster();
-    const target = actionTargetSnapshot(action, roster.sessions);
-    const kind = hostedSessionKind(action.kind);
-    if (kind === undefined) return refusedActionOutput(REFUSAL.NOT_HERE, target);
-    const providerId = "identity" in action ? action.identity.providerId : action.providerId;
-    if (!isCloudAgentProviderId(providerId)) return refusedActionOutput(REFUSAL.NOT_CLOUD, target);
-    const apiKey = await dependencies.apiKey(providerId);
-    if (standing.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER, target);
-    if (!apiKey) return refusedActionOutput(REFUSAL.NO_KEY, target);
-    return actionOutputFromResult(
-      carriedResult(
-        await dependencies.execute({
-          kind,
-          providerId,
-          fields,
-          apiKey,
-          roster: actionRosterFor(providerId, storedRosterOf(await dependencies.roster())),
-        }),
-      ),
-      target,
+  ): Effect.Effect<ActionOutputEnvelope> =>
+    Effect.gen(function* () {
+      const roster = yield* Effect.promise(() => dependencies.roster());
+      const target = actionTargetSnapshot(action, roster.sessions);
+      const kind = hostedSessionKind(action.kind);
+      if (kind === undefined) return refusedActionOutput(REFUSAL.NOT_HERE, target);
+      const providerId = "identity" in action ? action.identity.providerId : action.providerId;
+      if (!isCloudAgentProviderId(providerId))
+        return refusedActionOutput(REFUSAL.NOT_CLOUD, target);
+      const apiKey = yield* Effect.promise(() => dependencies.apiKey(providerId));
+      if (standing.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER, target);
+      if (!apiKey) return refusedActionOutput(REFUSAL.NO_KEY, target);
+      const stored = yield* Effect.promise(() => dependencies.roster());
+      const executed = yield* dependencies.execute({
+        kind,
+        providerId,
+        fields,
+        apiKey,
+        roster: actionRosterFor(providerId, storedRosterOf(stored)),
+      });
+      return actionOutputFromResult(carriedResult(executed), target);
+    });
+
+  const wrote = (
+    write: () => Promise<boolean>,
+    refusal: string,
+  ): Effect.Effect<ActionOutputEnvelope> =>
+    Effect.map(Effect.promise(write), (done) =>
+      done ? acceptedActionOutput() : refusedActionOutput(refusal),
     );
-  };
+
+  const notHere = (): Effect.Effect<ActionOutputEnvelope> =>
+    Effect.sync(() => refusedActionOutput(REFUSAL.NOT_HERE));
 
   return {
-    async admission() {
-      let read: Promise<HostedRoster> | undefined;
-      const roster = () => Effect.promise(() => (read ??= dependencies.roster()));
-      return {
-        roster: { read: () => Effect.map(roster(), (held) => held.sessions) },
-        projects: {
-          read: () => Effect.map(roster(), (held) => held.projects),
-          defaults: () => Effect.promise(() => dependencies.defaults()),
-          agentModels: workspaceAgentModels,
-        },
-        rememberedFacts: await dependencies.facts.list(),
-      };
-    },
+    admission: () =>
+      Effect.gen(function* () {
+        let read: Promise<HostedRoster> | undefined;
+        const roster = () => Effect.promise(() => (read ??= dependencies.roster()));
+        return {
+          roster: { read: () => Effect.map(roster(), (held) => held.sessions) },
+          projects: {
+            read: () => Effect.map(roster(), (held) => held.projects),
+            defaults: () => Effect.promise(() => dependencies.defaults()),
+            agentModels: workspaceAgentModels,
+          },
+          rememberedFacts: yield* Effect.promise(() => dependencies.facts.list()),
+        };
+      }),
     carry(action, fields, standing) {
-      if (standing.isRevoked())
-        return Promise.resolve(refusedActionOutput(ACTION_REFUSAL.TURN_OVER));
-      return dispatchByKind(action, {
-        [ACTION_KIND.REMEMBER]: async (remember) =>
-          (await dependencies.facts.remember({
-            id: randomUUID(),
-            words: remember.words,
-            ...(remember.replaces !== undefined ? { replaces: remember.replaces } : undefined),
-          }))
-            ? acceptedActionOutput()
-            : refusedActionOutput(REFUSAL.MEMORY_NOT_SAVED),
-        [ACTION_KIND.FORGET]: async (forget) =>
-          (await dependencies.facts.forget(forget.id))
-            ? acceptedActionOutput()
-            : refusedActionOutput(REFUSAL.MEMORY_NOT_REMOVED),
-        [ACTION_KIND.MESSAGE]: (carried) => carrySessionAction(carried, fields, standing),
-        [ACTION_KIND.CONTROL]: (carried) => carrySessionAction(carried, fields, standing),
-        [ACTION_KIND.CREATE_WORKSPACE]: (carried) => carrySessionAction(carried, fields, standing),
-        [ACTION_KIND.ADD_AGENT]: (carried) => carrySessionAction(carried, fields, standing),
-        [ACTION_KIND.RENAME_WORKSPACE]: (carried) => carrySessionAction(carried, fields, standing),
-        [ACTION_KIND.RENAME_SESSION]: (carried) => carrySessionAction(carried, fields, standing),
-        [ACTION_KIND.OPEN]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
-        [ACTION_KIND.SETTING]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
-        [ACTION_KIND.PANEL]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
-        [ACTION_KIND.FEEDBACK]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
-        [ACTION_KIND.UPDATE]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
+      return Effect.suspend(() => {
+        if (standing.isRevoked())
+          return Effect.succeed(refusedActionOutput(ACTION_REFUSAL.TURN_OVER));
+        return dispatchByKind(action, {
+          [ACTION_KIND.REMEMBER]: (remember) =>
+            wrote(
+              () =>
+                dependencies.facts.remember({
+                  id: randomUUID(),
+                  words: remember.words,
+                  ...(remember.replaces !== undefined
+                    ? { replaces: remember.replaces }
+                    : undefined),
+                }),
+              REFUSAL.MEMORY_NOT_SAVED,
+            ),
+          [ACTION_KIND.FORGET]: (forget) =>
+            wrote(() => dependencies.facts.forget(forget.id), REFUSAL.MEMORY_NOT_REMOVED),
+          [ACTION_KIND.MESSAGE]: (carried) => carrySessionAction(carried, fields, standing),
+          [ACTION_KIND.CONTROL]: (carried) => carrySessionAction(carried, fields, standing),
+          [ACTION_KIND.CREATE_WORKSPACE]: (carried) =>
+            carrySessionAction(carried, fields, standing),
+          [ACTION_KIND.ADD_AGENT]: (carried) => carrySessionAction(carried, fields, standing),
+          [ACTION_KIND.RENAME_WORKSPACE]: (carried) =>
+            carrySessionAction(carried, fields, standing),
+          [ACTION_KIND.RENAME_SESSION]: (carried) => carrySessionAction(carried, fields, standing),
+          [ACTION_KIND.OPEN]: notHere,
+          [ACTION_KIND.SETTING]: notHere,
+          [ACTION_KIND.PANEL]: notHere,
+          [ACTION_KIND.FEEDBACK]: notHere,
+          [ACTION_KIND.UPDATE]: notHere,
+        });
       });
     },
   };

--- a/apps/web/server/hosted/brain-host/tools.ts
+++ b/apps/web/server/hosted/brain-host/tools.ts
@@ -191,11 +191,11 @@ function runOf(
     case "action":
       return (fields, standing) =>
         Effect.gen(function* () {
-          const admission = yield* Effect.promise(() => seams.carrier.admission());
+          const admission = yield* seams.carrier.admission();
           return yield* named.module.execute(fields, {
             ...standing,
             admission,
-            carry: (action) => Effect.promise(() => seams.carrier.carry(action, fields, standing)),
+            carry: (action) => seams.carrier.carry(action, fields, standing),
           });
         });
     case "read":

--- a/apps/web/tests/hosted-actions.test.ts
+++ b/apps/web/tests/hosted-actions.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import type * as HttpClient from "@effect/platform/HttpClient";
 import { fakeHttpClientLayer } from "@sidecar/wire/testing";
-import type { Layer } from "effect";
+import { Effect, type Layer } from "effect";
 import { test } from "vitest";
 import type { JsonObject } from "../../../packages/wire/src/testing/json.js";
 import { ACTION_KIND, ACTION_REFUSAL, type WireRecord } from "../server/core";
@@ -439,14 +439,16 @@ async function ask(
 ): Promise<ActionExecutionAnswer> {
   const roster = await snapshotRoster(api);
   const readsBefore = api.reads.length;
-  const answer = await executeSessionAction({
-    kind,
-    providerId: "conductor",
-    fields: { provider_id: "conductor", ...fields },
-    apiKey: "key-1",
-    roster,
-    seams: { httpClient: api.layer },
-  });
+  const answer = await Effect.runPromise(
+    executeSessionAction({
+      kind,
+      providerId: "conductor",
+      fields: { provider_id: "conductor", ...fields },
+      apiKey: "key-1",
+      roster,
+      seams: { httpClient: api.layer },
+    }),
+  );
   // No read runs on an action: the snapshot is the roster, and the provider
   // sees only the write itself.
   assert.equal(api.reads.length, readsBefore);
@@ -524,18 +526,20 @@ async function seededRoster(httpClient: Layer.Layer<HttpClient.HttpClient>) {
 test("a key the provider refuses is named as the reason, not a missing session, and seeds no snapshot", async () => {
   const refusedKey = fakeHttpClientLayer(() => new Response("{}", { status: 401 }));
   const { roster, store } = await seededRoster(refusedKey);
-  const answer = await executeSessionAction({
-    kind: ACTION_KIND.MESSAGE,
-    providerId: "conductor",
-    fields: {
-      provider_id: "conductor",
-      provider_session_id: CONDUCTOR_SESSION_ID,
-      text: "hello",
-    },
-    apiKey: "key-1",
-    roster,
-    seams: { httpClient: fakeHttpClientLayer(async () => new Response("{}", { status: 401 })) },
-  });
+  const answer = await Effect.runPromise(
+    executeSessionAction({
+      kind: ACTION_KIND.MESSAGE,
+      providerId: "conductor",
+      fields: {
+        provider_id: "conductor",
+        provider_session_id: CONDUCTOR_SESSION_ID,
+        text: "hello",
+      },
+      apiKey: "key-1",
+      roster,
+      seams: { httpClient: fakeHttpClientLayer(async () => new Response("{}", { status: 401 })) },
+    }),
+  );
 
   assert.equal(answer.result, "rejected");
   assert.equal(store.snapshots.size, 0);
@@ -547,18 +551,20 @@ test("a provider that cannot be reached is named as the reason", async () => {
     throw new Error("connection refused");
   });
   const { roster } = await seededRoster(unreachable);
-  const answer = await executeSessionAction({
-    kind: ACTION_KIND.MESSAGE,
-    providerId: "conductor",
-    fields: {
-      provider_id: "conductor",
-      provider_session_id: CONDUCTOR_SESSION_ID,
-      text: "hello",
-    },
-    apiKey: "key-1",
-    roster,
-    seams: { httpClient: unreachable },
-  });
+  const answer = await Effect.runPromise(
+    executeSessionAction({
+      kind: ACTION_KIND.MESSAGE,
+      providerId: "conductor",
+      fields: {
+        provider_id: "conductor",
+        provider_session_id: CONDUCTOR_SESSION_ID,
+        text: "hello",
+      },
+      apiKey: "key-1",
+      roster,
+      seams: { httpClient: unreachable },
+    }),
+  );
 
   assert.equal(answer.result, "rejected");
 });

--- a/apps/web/tests/hosted-brain-host-tools.test.ts
+++ b/apps/web/tests/hosted-brain-host-tools.test.ts
@@ -124,10 +124,11 @@ function fakes(options: { readonly apiKey?: string } = { apiKey: "conductor-key"
     defaults: async () => ({}),
     facts: factsWriter(remembered),
     apiKey: async () => options.apiKey,
-    execute: async (input) => {
-      executed.push({ kind: input.kind, provider_id: input.providerId, ...input.fields });
-      return { result: ACTION_RESULT_STATUS.ACCEPTED };
-    },
+    execute: (input) =>
+      Effect.sync(() => {
+        executed.push({ kind: input.kind, provider_id: input.providerId, ...input.fields });
+        return { result: ACTION_RESULT_STATUS.ACCEPTED };
+      }),
   });
   const seams: HostedToolSeams = {
     conversation: { userId: "user-a", conversationId: "c-1" },

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -19,7 +19,7 @@ and the idioms the replacements write to are the "Effect idioms" section of the
 root `AGENTS.md`.
 
 Three things are deliberately not Effect's. The `Admitted` brand stays a
-type-level `unique symbol` with `admit()` its sole minter, never a
+type-level `unique symbol` with `admitEffect()` its sole minter, never a
 `Schema.brand`, because a brand a cast can spell is a brand anything can enter.
 The JSON Schema a model reads is emitted by `@sidecar/wire`'s own emitter
 (`packages/wire/src/effect/json-schema.ts`) rather than `JSONSchema.make`,
@@ -283,34 +283,16 @@ link that asks for a beat is a synchronous callback the calendars composer
 holds, so the pass is run to a promise on this composition's own runtime. It
 goes when that link answers an effect.
 
-`admit()` in `packages/actions/src/admit.ts` is the fourth: the gauntlet is
-`admitEffect()`, an Effect failing with an `AdmitRefusal`, and `admit()` runs it
-to the `Promise<ValidatedAction | Refusal>` its callers still hold, answering
-the refusal as the `Refusal` the action journal records and rethrowing a roster
-read's own failure. The brain's action tools left it in P12-15c and admit the
-call as an effect, since the `ToolExecutor` seam they run under answers one;
-what still holds the door is the web's action endpoint, which is a promise
-from `executeSessionAction` up, and the two testing doors over it
-(`@sidecar/actions`'s `tool-call.ts` and the provider contract's oracle).
-P12-15d made the reads the gauntlet itself waits on effects — `ActionRoster`'s
-and `ActionProjects`' own, and `guardedRead`, which is now an interruptible
-`raceFirst` between the read and the guard's signal rather than a promise race
-— so everything inside `admitEffect` is an effect and only that door is not.
-The `interruptible` is load-bearing: an action is carried through the journal
-inside an uninterruptible region, and a race there whose loser cannot be
-interrupted would never answer.
-P12-04 turned out to be the CloudFetch/HttpClient family alone, so the door
-waits on those three answering effects instead.
-
 `BrainTransport#send`'s internal `runCall` in `packages/brain/src/client.ts`
-is the fifth: every caller of the brain's model transport still holds a
-promise, not a fiber, so the request effect built over `@sidecar/hosted`'s
-`accountCall` is run to a promise there, joining the caller's own
-`AbortSignal` to the run exactly as `createAccountCall` does. P12-04d moved
-what it runs on: `BrainTransport` takes an `execution?: ExecutionRuntime`
-(the host's own, captured once in `compose-account.ts` as
-`Effect.runtime<never>()` and threaded through `VoiceCapabilityAssembler` to
-every adapter it builds) and `runCall` runs through `@sidecar/brain`'s shared
+is on the allowlist too: every caller of the brain's model transport still
+holds a promise, not a fiber, so the request effect built over
+`@sidecar/hosted`'s `accountCall` is run to a promise there, joining the
+caller's own `AbortSignal` to the run exactly as `createAccountCall` does.
+P12-04d moved what it runs on: `BrainTransport` takes an
+`execution?: ExecutionRuntime` (the host's own, captured once in
+`compose-account.ts` as `Effect.runtime<never>()` and threaded through
+`VoiceCapabilityAssembler` to every adapter it builds) and `runCall` runs
+through `@sidecar/brain`'s shared
 `runtimeExit(execution)` — the same door `tracedModelAdapter` runs through —
 rather than the ambient default runtime `Effect.runPromiseExit` read before.
 It is permanent alongside `tracedModelAdapter`, because what keeps both is
@@ -319,8 +301,8 @@ OpenClaw `b7528507` that awaits `model.respond` and imports nothing from
 `effect`, so no adapter above this transport can answer an effect while that
 port stands.
 
-`createAccountCall` in `packages/hosted/src/account-call.ts` is the sixth: it
-provides the caller's own `httpClient` layer, or `FetchHttpClient.layer` for
+`createAccountCall` in `packages/hosted/src/account-call.ts` is on it as well:
+it provides the caller's own `httpClient` layer, or `FetchHttpClient.layer` for
 the ambient ones, joins the caller's `AbortSignal` to the run, and answers
 the `Promise` its callers still hold. P12-04 moved every caller inside this
 package onto `accountCall` directly and deleted the `CloudFetch` seam this
@@ -1011,8 +993,8 @@ call before it runs and settles it after is one effect around another, and
 the batch the runtime already held uninterruptible is still what keeps a
 dispatched effect from being parted from its result. What stays a promise
 inside the executor is what the host hands it: the turn's checkpoint, the
-whole-transcript read, the child and workspace access, the memory provider's
-own tools, and the carrier an admitted action reaches.
+whole-transcript read, the child and workspace access, and the memory
+provider's own tools.
 
 The rest of this package's Promise faces turned out to stand on
 `BrainAgent`'s own public surface rather than on the vocabulary's: a wake, an
@@ -1215,7 +1197,6 @@ design decision stated as such:
 | TaggedErrors carry legacy `code` strings on wire | P3-04 onward | never — the wire is the compatibility surface |
 | `cloudFetchFromHttpClient` | P1-07 | P12-04e |
 | `timersFromRuntime` | P2-01 | P12-03 |
-| `admit()` Promise door over `admitEffect()` | P4-01 | pending — the brain's action tools stopped using it in P12-15c; blocked now on the web's `executeSessionAction` and the two testing doors over it answering effects |
 | `BrainTransport#send`'s internal `runCall`, over `runtimeExit(execution)` since P12-04d | P5-05 | never — permanent alongside `tracedModelAdapter`, `compaction.ts`'s `ModelAdapter` stays a promise |
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04b |
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04b |

--- a/packages/actions/src/actions.test.ts
+++ b/packages/actions/src/actions.test.ts
@@ -27,12 +27,14 @@ const appToolAction = (
   sessions: readonly never[],
   rememberedFacts: readonly RememberedFact[],
 ) =>
-  admitToolCall(call, {
-    origin: RUN_ORIGIN.USER,
-    roster: { read: () => Effect.succeed(sessions) },
-    guide,
-    rememberedFacts,
-  });
+  Effect.runPromise(
+    admitToolCall(call, {
+      origin: RUN_ORIGIN.USER,
+      roster: { read: () => Effect.succeed(sessions) },
+      guide,
+      rememberedFacts,
+    }),
+  );
 
 test("a setting action narrates the setting label and accepted value", async () => {
   assert.equal(

--- a/packages/actions/src/admit-effect.test.ts
+++ b/packages/actions/src/admit-effect.test.ts
@@ -9,16 +9,15 @@ import {
   type Session,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { Cause, Deferred, Effect, Exit, Fiber } from "effect";
 import { ACTION_KIND } from "./action-kinds.js";
-import { ACTION_REFUSAL, type AdmitContext, AdmitRefusal, admit, admitEffect } from "./admit.js";
+import { ACTION_REFUSAL, type AdmitContext, AdmitRefusal, admitEffect } from "./admit.js";
 
 /**
  * The gauntlet as an Effect: what it succeeds with, what it fails with, and
- * that the Promise door answers the same decision in the shape its callers
- * still hold. Each case asserts the refusal's tag and its reason as values,
- * because the reason is what the action journal records and Luke says aloud.
+ * what it reads to decide. Each case asserts the refusal's tag and its reason
+ * as values, because the reason is what the action journal records and Luke
+ * says aloud.
  */
 
 const NOW = 1_800_000_000_000;
@@ -297,33 +296,6 @@ describe("admitEffect", () => {
       assert.equal(admitted.kind, ACTION_KIND.MESSAGE);
     }),
   );
-});
-
-describe("admit", () => {
-  it("answers the refusal as the record the action journal takes", async () => {
-    const answer = await admit(MESSAGE, context({ sessions: [] }));
-    assert.deepEqual(answer, {
-      status: ACTION_RESULT_STATUS.REJECTED,
-      reason: ACTION_REFUSAL.NO_SESSION,
-    });
-  });
-
-  it("rejects with a roster read's own failure, not a wrapper of it", async () => {
-    const failure = new Error("roster offline");
-    await assert.rejects(
-      admit(MESSAGE, {
-        origin: RUN_ORIGIN.USER,
-        roster: { read: () => Effect.promise(() => Promise.reject(failure)) },
-      }),
-      (caught) => caught === failure,
-    );
-  });
-
-  it("answers what the effect succeeded with", async () => {
-    const admitted = await admit(MESSAGE, context());
-    assert.equal(admitted.kind, ACTION_KIND.MESSAGE);
-    assert.equal(admitted.origin, RUN_ORIGIN.USER);
-  });
 });
 
 it("AdmitRefusal is the tagged error the gauntlet fails with", () => {

--- a/packages/actions/src/admit.test.ts
+++ b/packages/actions/src/admit.test.ts
@@ -47,15 +47,17 @@ async function sessionToolAction(
   defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
 ) {
   return withoutAdmission(
-    await admitToolCall(call, {
-      origin: RUN_ORIGIN.USER,
-      roster: { read: () => Effect.succeed(sessions) },
-      projects: {
-        read: () => Effect.succeed(workspaceProjects),
-        defaults: () => Effect.succeed({ defaultProviderId, defaultProjectIds }),
-        agentModels,
-      },
-    }),
+    await Effect.runPromise(
+      admitToolCall(call, {
+        origin: RUN_ORIGIN.USER,
+        roster: { read: () => Effect.succeed(sessions) },
+        projects: {
+          read: () => Effect.succeed(workspaceProjects),
+          defaults: () => Effect.succeed({ defaultProviderId, defaultProjectIds }),
+          agentModels,
+        },
+      }),
+    ),
   );
 }
 

--- a/packages/actions/src/admit.ts
+++ b/packages/actions/src/admit.ts
@@ -9,9 +9,8 @@
  * so an action whose turn ended while the roster was refreshing refuses rather
  * than dispatching.
  *
- * The gauntlet is an Effect, {@link admitEffect}, failing with the refusal as a
- * typed error; {@link admit} is the Promise door over it that every caller
- * still holds, and the one place in this package an Effect is run.
+ * The gauntlet is one Effect, {@link admitEffect}, failing with the refusal as
+ * a typed error, and every caller composes it into its own.
  *
  * Admission decides only whether an action may run. Which acts a conversation may
  * ask for at all was the effective tool policy's decision before a call left
@@ -57,7 +56,7 @@ import {
   text as wireText,
 } from "@sidecar/wire";
 import { readEither } from "@sidecar/wire/effect";
-import { Cause, Data, Effect, Either, Exit, Option, type Schema } from "effect";
+import { Data, Effect, Either, type Schema } from "effect";
 import {
   ACTION_KIND,
   type ActionKind,
@@ -90,12 +89,12 @@ import {
 /**
  * An action that ran the gauntlet, carrying the turn's origin for Conversation to
  * record. The brand is `@sidecar/wire`'s, whose key nothing anywhere can spell,
- * and {@link admit} below is the one place in the repository that enters the
- * admitted set: everything downstream re-shapes what it already holds. What the
- * brand buys is that admission cannot be skipped by accident; a deliberate
+ * and {@link admitEffect} below is the one place in the repository that enters
+ * the admitted set: everything downstream re-shapes what it already holds. What
+ * the brand buys is that admission cannot be skipped by accident; a deliberate
  * `as ValidatedAction` would still compile, since the admitted action is a subtype of
- * its own payload, and that assertion appears nowhere but in `admit` itself —
- * `validated-action.type-test.ts` says both in as many words.
+ * its own payload, and that assertion appears nowhere but in `admitEffect`
+ * itself — `validated-action.type-test.ts` says both in as many words.
  */
 export type ValidatedAction<Kind extends ActionKind = ActionKind> = Admitted<
   CarriedAction<Kind>
@@ -970,24 +969,4 @@ export function admitEffect<Kind extends ActionKind>(
     // repository; the payload stands exactly as the admitter built it.
     return { ...admitted, origin: context.origin } as ValidatedAction<Kind>;
   });
-}
-
-/**
- * {@link admitEffect} answered as the Promise every caller still holds: the
- * refusal comes back as the {@link Refusal} the action journal records, and a
- * roster read that failed rejects with its own failure, as it always has. This
- * door is the strangler shim that runs the effect where no runtime edge does
- * yet; callers move onto `admitEffect` as their own runs become Effects
- * (P5-14b's turn runner, P7's composers), and the door goes with the `Settled`
- * Promise signatures in P12-02.
- */
-export async function admit<Kind extends ActionKind>(
-  request: ActionRequest<Kind>,
-  context: AdmitContext,
-): Promise<ValidatedAction<Kind> | Refusal> {
-  const exit = await Effect.runPromiseExit(admitEffect(request, context));
-  if (Exit.isSuccess(exit)) return exit.value;
-  const refusal = Cause.failureOption(exit.cause);
-  if (Option.isSome(refusal)) return refuse(refusal.value.reason);
-  throw Cause.squash(exit.cause);
 }

--- a/packages/actions/src/guarantees.test.ts
+++ b/packages/actions/src/guarantees.test.ts
@@ -21,11 +21,11 @@ import {
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { Effect } from "effect";
 import { test } from "vitest";
-import { ACTION_KIND, type ActionKind } from "./action-kinds.js";
+import { ACTION_KIND, type ActionKind, type ActionRequest } from "./action-kinds.js";
 import {
   ACTION_REFUSAL,
   type AdmitContext,
-  admit,
+  admitEffect,
   type Refusal,
   type ValidatedAction,
 } from "./admit.js";
@@ -140,6 +140,25 @@ const SESSION_KINDS = [
 // SAFETY: the table above is keyed by every action kind and by nothing else.
 const EVERY_KIND = Object.keys(FIELDS) as readonly ActionKind[];
 
+/**
+ * The gauntlet's decision as the one value these cases read: what
+ * `admitEffect` succeeded with, or the refusal it failed with as the record
+ * the action journal takes. A roster read that fails is left to reject, which
+ * is what `admit-effect.test.ts` holds it to.
+ */
+function decide<Kind extends ActionKind>(
+  request: ActionRequest<Kind>,
+  context: AdmitContext,
+): Promise<ValidatedAction<Kind> | Refusal> {
+  return Effect.runPromise(
+    Effect.catchAll(
+      admitEffect(request, context),
+      (refusal): Effect.Effect<ValidatedAction<Kind> | Refusal> =>
+        Effect.succeed({ status: ACTION_RESULT_STATUS.REJECTED, reason: refusal.reason }),
+    ),
+  );
+}
+
 function refused(result: ValidatedAction | Refusal): string {
   assert.equal(result.kind, undefined, "expected a refusal");
   assert.ok(result.kind === undefined);
@@ -150,7 +169,7 @@ function refused(result: ValidatedAction | Refusal): string {
 test("each validated against the observed roster before an adapter sees it", async () => {
   const elsewhere = context({ sessions: [] });
   for (const kind of SESSION_KINDS) {
-    const answer = await admit({ kind, fields: FIELDS[kind] }, elsewhere);
+    const answer = await decide({ kind, fields: FIELDS[kind] }, elsewhere);
     assert.equal(refused(answer), ACTION_REFUSAL.NO_SESSION, kind);
   }
   assert.equal(elsewhere.rosterReads(), SESSION_KINDS.length);
@@ -159,14 +178,14 @@ test("each validated against the observed roster before an adapter sees it", asy
 test("a fresh roster read precedes it, and admission reads it once per action", async () => {
   for (const kind of SESSION_KINDS) {
     const standing = context();
-    assert.notEqual((await admit({ kind, fields: FIELDS[kind] }, standing)).kind, undefined, kind);
+    assert.notEqual((await decide({ kind, fields: FIELDS[kind] }, standing)).kind, undefined, kind);
     assert.equal(standing.rosterReads(), 1, kind);
   }
 });
 
 test("its target has to be one the roster holds", async () => {
   // The same session id under another provider is another session, and names nothing.
-  const answer = await admit(
+  const answer = await decide(
     { kind: ACTION_KIND.MESSAGE, fields: { ...FIELDS[ACTION_KIND.MESSAGE], provider_id: "codex" } },
     context(),
   );
@@ -177,7 +196,7 @@ test("a cancellation or a revoked run refuses it", async () => {
   for (const kind of EVERY_KIND) {
     const revoked = context({ guard: { isRevoked: () => true } });
     assert.equal(
-      refused(await admit({ kind, fields: FIELDS[kind] }, revoked)),
+      refused(await decide({ kind, fields: FIELDS[kind] }, revoked)),
       ACTION_REFUSAL.TURN_OVER,
       kind,
     );
@@ -188,7 +207,7 @@ test("a cancellation or a revoked run refuses it", async () => {
 test("a turn that ends while the roster is read refuses rather than dispatching", async () => {
   let over = false;
   const controller = new AbortController();
-  const answer = await admit(
+  const answer = await decide(
     { kind: ACTION_KIND.MESSAGE, fields: FIELDS[ACTION_KIND.MESSAGE] },
     {
       origin: RUN_ORIGIN.USER,
@@ -211,7 +230,7 @@ test("a read still out when the signal fires answers nothing, and the action ref
   const held = new Promise<readonly Session[]>((resolve) => {
     release = () => resolve([offering()]);
   });
-  const pending = admit(
+  const pending = decide(
     { kind: ACTION_KIND.MESSAGE, fields: FIELDS[ACTION_KIND.MESSAGE] },
     {
       origin: RUN_ORIGIN.USER,
@@ -226,7 +245,7 @@ test("a read still out when the signal fires answers nothing, and the action ref
 
 test("a control its provider advertised for it, and never the caller's copy", async () => {
   const roster = [offering()];
-  const admitted = await admit(
+  const admitted = await decide(
     { kind: ACTION_KIND.CONTROL, fields: FIELDS[ACTION_KIND.CONTROL] },
     context({ sessions: roster }),
   );
@@ -238,7 +257,7 @@ test("a control its provider advertised for it, and never the caller's copy", as
   assert.deepEqual(admitted.control, advertised);
   assert.equal(
     refused(
-      await admit(
+      await decide(
         { kind: ACTION_KIND.CONTROL, fields: { ...IDENTITY, control_id: "terminate" } },
         context(),
       ),
@@ -254,7 +273,7 @@ test("a session whose current state is documented for none advertises nothing an
   for (const kind of SESSION_KINDS) {
     if (kind === ACTION_KIND.OPEN) continue;
     assert.notEqual(
-      refused(await admit({ kind, fields: { ...FIELDS[kind], ...named } }, quiet)),
+      refused(await decide({ kind, fields: { ...FIELDS[kind], ...named } }, quiet)),
       "",
       kind,
     );
@@ -268,21 +287,21 @@ test("local sessions have no such endpoint and stay entirely read-only", async (
   for (const kind of SESSION_KINDS) {
     if (kind === ACTION_KIND.OPEN) continue;
     assert.equal(
-      (await admit({ kind, fields: { ...FIELDS[kind], ...named } }, observed)).kind,
+      (await decide({ kind, fields: { ...FIELDS[kind], ...named } }, observed)).kind,
       undefined,
       kind,
     );
   }
   // An open is not a write, and a session reporting no address is offered nowhere to open.
   assert.equal(
-    refused(await admit({ kind: ACTION_KIND.OPEN, fields: named }, observed)),
+    refused(await decide({ kind: ACTION_KIND.OPEN, fields: named }, observed)),
     ACTION_REFUSAL.NO_ADDRESS,
   );
 });
 
 test("the developer's own text, bounded and refused rather than cut", async () => {
   const atBound = "a".repeat(maximumSessionMessageLength);
-  const admitted = await admit(
+  const admitted = await decide(
     { kind: ACTION_KIND.MESSAGE, fields: { ...IDENTITY, text: atBound } },
     context(),
   );
@@ -290,7 +309,7 @@ test("the developer's own text, bounded and refused rather than cut", async () =
   assert.equal(admitted.text, atBound);
   assert.equal(
     refused(
-      await admit(
+      await decide(
         { kind: ACTION_KIND.MESSAGE, fields: { ...IDENTITY, text: `${atBound}a` } },
         context(),
       ),
@@ -299,21 +318,24 @@ test("the developer's own text, bounded and refused rather than cut", async () =
   );
   const name = "n".repeat(maximumWorkspaceNameLength + 1);
   for (const kind of [ACTION_KIND.RENAME_WORKSPACE, ACTION_KIND.RENAME_SESSION] as const) {
-    assert.equal((await admit({ kind, fields: { ...IDENTITY, name } }, context())).kind, undefined);
+    assert.equal(
+      (await decide({ kind, fields: { ...IDENTITY, name } }, context())).kind,
+      undefined,
+    );
   }
 });
 
 test("lands only in a project its provider reported on the latest observation pass", async () => {
   assert.equal(
     refused(
-      await admit(
+      await decide(
         { kind: ACTION_KIND.CREATE_WORKSPACE, fields: { project_id: "/Users/me/other" } },
         context(),
       ),
     ),
     ACTION_REFUSAL.NO_PROJECT,
   );
-  const admitted = await admit(
+  const admitted = await decide(
     { kind: ACTION_KIND.CREATE_WORKSPACE, fields: { project_id: "luke" } },
     context(),
   );
@@ -323,7 +345,7 @@ test("lands only in a project its provider reported on the latest observation pa
   assert.equal(admitted.providerProjectId, LISTED_PROJECT.providerProjectId);
   // A target the ask invents for a project listed without one names no host
   // to pick, so it neither hides the project nor rides the action.
-  const targeted = await admit(
+  const targeted = await decide(
     { kind: ACTION_KIND.CREATE_WORKSPACE, fields: { project_id: "luke", target_id: "default" } },
     context(),
   );
@@ -343,7 +365,7 @@ test("each project says whether it takes a task, needs one, or takes none", asyn
     });
   assert.equal(
     refused(
-      await admit(
+      await decide(
         { kind: ACTION_KIND.CREATE_WORKSPACE, fields: { project_id: "luke", task: "start" } },
         withSupport(WORKSPACE_TASK_SUPPORT.NONE),
       ),
@@ -352,7 +374,7 @@ test("each project says whether it takes a task, needs one, or takes none", asyn
   );
   assert.equal(
     refused(
-      await admit(
+      await decide(
         { kind: ACTION_KIND.CREATE_WORKSPACE, fields: { project_id: "luke" } },
         withSupport(WORKSPACE_TASK_SUPPORT.REQUIRED),
       ),
@@ -364,14 +386,14 @@ test("each project says whether it takes a task, needs one, or takes none", asyn
 test("as one of the agent kinds that row's latest observation listed", async () => {
   assert.equal(
     refused(
-      await admit(
+      await decide(
         { kind: ACTION_KIND.ADD_AGENT, fields: { ...IDENTITY, agent: "opencode" } },
         context(),
       ),
     ),
     ACTION_REFUSAL.NO_SESSION_AGENT,
   );
-  const admitted = await admit(
+  const admitted = await decide(
     { kind: ACTION_KIND.ADD_AGENT, fields: FIELDS[ACTION_KIND.ADD_AGENT] },
     context(),
   );
@@ -382,7 +404,7 @@ test("as one of the agent kinds that row's latest observation listed", async () 
 test("who opened a turn is recorded on the action and is never by itself a permission", async () => {
   const answers = await Promise.all(
     Object.values(RUN_ORIGIN).map(async (origin) => {
-      const admitted = await admit(
+      const admitted = await decide(
         { kind: ACTION_KIND.MESSAGE, fields: FIELDS[ACTION_KIND.MESSAGE] },
         { ...context(), origin },
       );
@@ -398,7 +420,7 @@ test("who opened a turn is recorded on the action and is never by itself a permi
 test("a setting the guide does not carry is one the conversation cannot change", async () => {
   assert.equal(
     refused(
-      await admit(
+      await decide(
         { kind: ACTION_KIND.SETTING, fields: FIELDS[ACTION_KIND.SETTING] },
         { ...context(), guide: EMPTY_APP_GUIDE },
       ),
@@ -408,13 +430,13 @@ test("a setting the guide does not carry is one the conversation cannot change",
   // A run that reports nothing about itself changes nothing about itself.
   assert.equal(
     refused(
-      await admit({ kind: ACTION_KIND.SETTING, fields: FIELDS[ACTION_KIND.SETTING] }, context()),
+      await decide({ kind: ACTION_KIND.SETTING, fields: FIELDS[ACTION_KIND.SETTING] }, context()),
     ),
     ACTION_REFUSAL.NO_SETTING,
   );
   assert.equal(
     refused(
-      await admit({ kind: ACTION_KIND.UPDATE, fields: FIELDS[ACTION_KIND.UPDATE] }, context()),
+      await decide({ kind: ACTION_KIND.UPDATE, fields: FIELDS[ACTION_KIND.UPDATE] }, context()),
     ),
     ACTION_REFUSAL.NO_UPDATE_REPORT,
   );
@@ -424,12 +446,12 @@ test("only an id from the remembered list can be named, and the cap refuses rath
   const held = [{ id: "fact-one", words: "prefers concise answers" }];
   const notebook = context({ rememberedFacts: held });
   assert.equal(
-    refused(await admit({ kind: ACTION_KIND.FORGET, fields: { id: "fact-two" } }, notebook)),
+    refused(await decide({ kind: ACTION_KIND.FORGET, fields: { id: "fact-two" } }, notebook)),
     ACTION_REFUSAL.NO_SUCH_FACT,
   );
   assert.equal(
     refused(
-      await admit(
+      await decide(
         { kind: ACTION_KIND.REMEMBER, fields: { words: "x", replaces: "fact-two" } },
         notebook,
       ),
@@ -442,7 +464,7 @@ test("only an id from the remembered list can be named, and the cap refuses rath
   }));
   assert.equal(
     refused(
-      await admit(
+      await decide(
         { kind: ACTION_KIND.REMEMBER, fields: FIELDS[ACTION_KIND.REMEMBER] },
         context({ rememberedFacts: full }),
       ),
@@ -452,7 +474,7 @@ test("only an id from the remembered list can be named, and the cap refuses rath
 });
 
 test("opening a session is not a write: the action carries an identity, never an address", async () => {
-  const admitted = await admit(
+  const admitted = await decide(
     { kind: ACTION_KIND.OPEN, fields: FIELDS[ACTION_KIND.OPEN] },
     context(),
   );
@@ -486,7 +508,7 @@ const READS = {
 test("each action is admitted against the observed state it names, and against nothing wider", async () => {
   for (const kind of EVERY_KIND) {
     const reached: string[] = [];
-    await admit(
+    await decide(
       { kind, fields: FIELDS[kind] },
       {
         origin: RUN_ORIGIN.USER,

--- a/packages/actions/src/guide.test.ts
+++ b/packages/actions/src/guide.test.ts
@@ -39,11 +39,13 @@ async function appToolAction(
   sessions: readonly Session[],
 ) {
   return withoutAdmission(
-    await admitToolCall(functionCall, {
-      origin: RUN_ORIGIN.USER,
-      roster: { read: () => Effect.succeed(sessions) },
-      guide,
-    }),
+    await Effect.runPromise(
+      admitToolCall(functionCall, {
+        origin: RUN_ORIGIN.USER,
+        roster: { read: () => Effect.succeed(sessions) },
+        guide,
+      }),
+    ),
   );
 }
 

--- a/packages/actions/src/testing/tool-call.ts
+++ b/packages/actions/src/testing/tool-call.ts
@@ -1,10 +1,11 @@
 import { ACTION_RESULT_STATUS, isRecord, type UnparsedWireValue } from "@sidecar/wire";
+import { Effect } from "effect";
 import type { ActionFunctionCall } from "../action-kinds.js";
 import { ACTIONS } from "../actions.js";
 import {
   ACTION_REFUSAL,
   type AdmitContext,
-  admit,
+  admitEffect,
   type Refusal,
   type ValidatedAction,
 } from "../admit.js";
@@ -12,25 +13,36 @@ import {
 /**
  * One model-emitted tool call admitted the way a tool module admits it: the
  * name selects the action, the arguments are read as that action's own
- * fields, and `admit` is the whole of validation. For tests that speak in
- * calls; the build's own modules parse their arguments before `admit` sees
- * them and never take a call.
+ * fields, and `admitEffect` is the whole of validation. For tests that speak
+ * in calls; the build's own modules parse their arguments before admission
+ * sees them and never take a call.
+ *
+ * The decision is the effect's success either way, since a call this door
+ * could not read is refused before the gauntlet runs and a case reads both
+ * refusals the same. A roster read that fails is still the defect it is
+ * inside `admitEffect`.
  */
-export async function admitToolCall(
+export function admitToolCall(
   call: ActionFunctionCall,
   context: AdmitContext,
-): Promise<ValidatedAction | Refusal> {
-  const spec = Object.values(ACTIONS).find((candidate) => candidate.name === call.name);
-  if (!spec) return { status: ACTION_RESULT_STATUS.REJECTED, reason: ACTION_REFUSAL.NO_TOOL };
-  let parsed: UnparsedWireValue;
-  try {
-    // SAFETY: JSON.parse answers a wire value; the record check is the validation.
-    parsed = JSON.parse(call.argumentsJson) as UnparsedWireValue;
-  } catch {
-    return { status: ACTION_RESULT_STATUS.REJECTED, reason: ACTION_REFUSAL.UNREADABLE };
-  }
-  if (!isRecord(parsed)) {
-    return { status: ACTION_RESULT_STATUS.REJECTED, reason: ACTION_REFUSAL.UNREADABLE };
-  }
-  return admit({ kind: spec.kind, fields: parsed }, context);
+): Effect.Effect<ValidatedAction | Refusal> {
+  return Effect.suspend(() => {
+    const spec = Object.values(ACTIONS).find((candidate) => candidate.name === call.name);
+    if (!spec) return Effect.succeed(refused(ACTION_REFUSAL.NO_TOOL));
+    let parsed: UnparsedWireValue;
+    try {
+      // SAFETY: JSON.parse answers a wire value; the record check is the validation.
+      parsed = JSON.parse(call.argumentsJson) as UnparsedWireValue;
+    } catch {
+      return Effect.succeed(refused(ACTION_REFUSAL.UNREADABLE));
+    }
+    if (!isRecord(parsed)) return Effect.succeed(refused(ACTION_REFUSAL.UNREADABLE));
+    return Effect.catchAll(admitEffect({ kind: spec.kind, fields: parsed }, context), (refusal) =>
+      Effect.succeed(refused(refusal.reason)),
+    );
+  });
+}
+
+function refused(reason: string): Refusal {
+  return { status: ACTION_RESULT_STATUS.REJECTED, reason };
 }

--- a/packages/brain/src/performer.ts
+++ b/packages/brain/src/performer.ts
@@ -32,7 +32,7 @@ export type BrainActionExecution = ToolContext;
 
 /**
  * The host's two halves of carrying an action, which the action tool's own
- * `execute` joins with `admit()` between them: the readers admission
+ * `execute` joins with `admitEffect()` between them: the readers admission
  * consults for an execution, and the carrier, which takes only what
  * admission minted and answers in the one envelope every action tool shares —
  * the status, the target as the roster held it at execution, and the session

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -6,10 +6,9 @@ import {
   ACTION_OUTPUT_STATUS,
   ACTION_REFUSAL,
   ACTION_TOOL,
-  admit,
+  admitEffect,
   type CarriedActionResult,
   type CarriedSessionAction,
-  type Refusal,
   type RememberedFact,
   type ValidatedAction,
 } from "@sidecar/actions";
@@ -478,21 +477,29 @@ test("an admitted action with no turn standing is refused at the carrier, the ho
     guide: CAPTIONS_GUIDE,
     rememberedFacts: [],
   };
-  const minted: readonly (ValidatedAction | Refusal)[] = await Promise.all([
-    admit(
-      {
-        kind: ACTION_KIND.MESSAGE,
-        fields: { provider_id: "claude-code", provider_session_id: "session-a", text: "go ahead" },
-      },
-      standing,
-    ),
-    admit({ kind: ACTION_KIND.REMEMBER, fields: { words: "prefers concise answers" } }, standing),
-    admit(
-      { kind: ACTION_KIND.SETTING, fields: { setting_id: "voice_captions", value: "on" } },
-      standing,
-    ),
-  ]);
-  const admitted = minted.filter((action): action is ValidatedAction => action.kind !== undefined);
+  const admitted: readonly ValidatedAction[] = await Effect.runPromise(
+    Effect.all([
+      admitEffect(
+        {
+          kind: ACTION_KIND.MESSAGE,
+          fields: {
+            provider_id: "claude-code",
+            provider_session_id: "session-a",
+            text: "go ahead",
+          },
+        },
+        standing,
+      ),
+      admitEffect(
+        { kind: ACTION_KIND.REMEMBER, fields: { words: "prefers concise answers" } },
+        standing,
+      ),
+      admitEffect(
+        { kind: ACTION_KIND.SETTING, fields: { setting_id: "voice_captions", value: "on" } },
+        standing,
+      ),
+    ]),
+  );
   assert.equal(admitted.length, 3);
   // SAFETY: the carrier is the last gate before an effect and reads its
   // context as untrusted; these are the shapes a broken caller could hand it.

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -68,7 +68,7 @@ export interface SessionActionPerformerDependencies {
   /**
    * The service's side of every session write. The service admits each
    * against the stored snapshot this Mac's rows were drawn from, by the same
-   * `admit()` the brain already ran here, builds the write from that
+   * `admitEffect()` the brain already ran here, builds the write from that
    * snapshot's own advertisement, and answers what the provider said.
    */
   actions: Pick<
@@ -97,7 +97,7 @@ export interface SessionActionPerformerDependencies {
 /**
  * The one entry every action on a session passes through. The brain
  * is the only caller, and what arrives is a `ValidatedAction`, which only
- * `admit()` mints: whether the action may run was decided there, against the
+ * `admitEffect()` mints: whether the action may run was decided there, against the
  * roster it read for itself, so what is left here is carrying it — a session
  * write to the service that admits it once more against the same stored
  * snapshot — and counting what landed. The opens are exposed on their own

--- a/packages/host/src/session-row-actions.ts
+++ b/packages/host/src/session-row-actions.ts
@@ -42,7 +42,7 @@ export interface SessionRowActionsDependencies {
  * composer and the press of a control its provider advertised. They are the
  * developer's own acts, and they are admitted where the roster is: the
  * service admits each against the stored snapshot the row was drawn from,
- * by the same `admit()` every action runs, builds the write from that
+ * by the same `admitEffect()` every action runs, builds the write from that
  * snapshot's own advertisement, and answers what the provider said. The one
  * thing decided here is that the row still stands — a session the drawn
  * roster no longer holds is refused without a call, as it always was. A

--- a/packages/memory/src/provider.ts
+++ b/packages/memory/src/provider.ts
@@ -35,7 +35,7 @@ import type { NotebookMemoryAccess } from "./notebook-memory.js";
  * which the index answers, each a module of the shape every tool of the
  * brain is declared in. The notebook's two writes, `remember_fact` and
  * `forget_fact`, are rows of the actions table and action tools of the
- * brain's own: admitted inside their module by the same `admit()` as every
+ * brain's own: admitted inside their module by the same `admitEffect()` as every
  * other action and carried by the host's performer to the store's worker, so
  * no call of theirs reaches the host raw, and nothing here carries one. The
  * provider is built over one scope and answers for no other.

--- a/packages/providers/src/testing/provider-contract.ts
+++ b/packages/providers/src/testing/provider-contract.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { type ActionKind, type ActionRequest, admit } from "@sidecar/actions";
+import {
+  type ActionKind,
+  type ActionRequest,
+  type AdmitContext,
+  admitEffect,
+  type Refusal,
+  type ValidatedAction,
+} from "@sidecar/actions";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import {
   ACTION_KIND,
@@ -30,6 +37,7 @@ import {
   type JsonObject,
   type JsonValue,
   recordedRoutes,
+  runTest,
   temporaryDirectory,
 } from "@sidecar/wire/testing";
 import { Effect } from "effect";
@@ -137,11 +145,12 @@ const ADVERTISED_ACTION_KINDS = Object.values({
 
 /**
  * The roster and the request as admission reads them, over this provider's own
- * recorded pass. The two cases below hold `admit()` to a sentence rather than
- * the adapter, because admission is where the sentence now lives — and they
- * run per provider so each provider's own advertisement shape is what is read.
+ * recorded pass. The two cases below hold `admitEffect()` to a sentence rather
+ * than the adapter, because admission is where the sentence now lives — and
+ * they run per provider so each provider's own advertisement shape is what is
+ * read.
  */
-function admissionOver(plugin: SessionProviderPlugin) {
+function admissionOver(plugin: SessionProviderPlugin): AdmitContext {
   return {
     origin: RUN_ORIGIN.USER,
     roster: {
@@ -149,6 +158,24 @@ function admissionOver(plugin: SessionProviderPlugin) {
         Effect.succeed(plugin.latest().map((one) => normalizeSession(plugin.provider, one))),
     },
   };
+}
+
+/**
+ * The gauntlet's decision as one value: what it minted, or the refusal it
+ * failed with in the shape the action journal records. A case here reads both
+ * the same, because what it is holding admission to is the sentence.
+ */
+function decide(
+  request: ActionRequest<ActionKind>,
+  context: AdmitContext,
+): Promise<ValidatedAction | Refusal> {
+  return runTest(
+    Effect.catchAll(
+      admitEffect(request, context),
+      (refusal): Effect.Effect<ValidatedAction | Refusal> =>
+        Effect.succeed({ status: ACTION_RESULT_STATUS.REJECTED, reason: refusal.reason }),
+    ),
+  );
 }
 
 function admissionRequest(
@@ -460,7 +487,7 @@ export function describeProviderContract(
     const requestsAfterPass = api.requests().length;
 
     for (const kind of fixtures.advertised) {
-      const admitted = await admit(
+      const admitted = await decide(
         admissionRequest(plugin, kind, fixtures.absentSessionId, {
           ...advertisementFor(plugin, fixtures, kind),
         }),
@@ -530,7 +557,7 @@ export function describeProviderContract(
       const overLong = "l".repeat(maximumSessionMessageLength + 1);
 
       for (const text of ["", "   ", overLong]) {
-        const admitted = await admit(
+        const admitted = await decide(
           admissionRequest(plugin, ACTION_KIND.MESSAGE, fixtures.sessionId, { text }),
           admissionOver(plugin),
         );

--- a/packages/session/src/provider-contract.ts
+++ b/packages/session/src/provider-contract.ts
@@ -4,7 +4,7 @@ import type { WorkspaceAgentSelection } from "./workspace-agents.js";
 
 /**
  * What each action is asked with. Every one is an `Admitted` request, which only
- * `admit()` in `@sidecar/actions` stands behind: the session or project was one
+ * `admitEffect()` in `@sidecar/actions` stands behind: the session or project was one
  * the roster that pass reported, the action was one it advertised, and the
  * developer's text was bounded, before a provider saw any of it. What a
  * provider answers for is its own route — the advertised control, spawn

--- a/packages/session/src/provider-plugin.ts
+++ b/packages/session/src/provider-plugin.ts
@@ -81,7 +81,7 @@ export type ConversationPage = Omit<ProviderConversationRequest, "providerSessio
 
 /**
  * Every action a plugin performs takes an admitted input, for the same reason an
- * adapter's write does: only `admit()` in `@sidecar/actions` mints one, so a
+ * adapter's write does: only `admitEffect()` in `@sidecar/actions` mints one, so a
  * handler cannot be reached by anything that skipped the gauntlet. The reads
  * below take the plain input — a read is not a write and admits nothing.
  */
@@ -313,7 +313,7 @@ const ACTION_DISPATCHERS: ActionDispatchers = {
  * acts on what the pass saw and never on what a caller sent, and answers
  * unsupported for a session the pass did not report or an action the plugin does
  * not name. Whether the action may run at all was answered before it arrived:
- * only `admit()` mints the request this takes.
+ * only `admitEffect()` mints the request this takes.
  */
 export function dispatchAction<Kind extends PluginActionKind>(
   plugin: SessionProviderPlugin,

--- a/packages/wire/src/admitted.ts
+++ b/packages/wire/src/admitted.ts
@@ -3,7 +3,7 @@
  * take to say the gauntlet ran. The brand key is a module-private
  * `unique symbol`, so nothing anywhere can spell it: an object literal is
  * never an admitted value, and the whole set is entered at exactly one place
- * in the repository — the cast inside `admit()` in `@sidecar/actions`, whose job
+ * in the repository — the cast inside `admitEffect()` in `@sidecar/actions`, whose job
  * is to be that place. Everything downstream of it re-shapes what it already
  * holds through {@link reshapeAdmitted}, which needs an admitted value of its
  * own to answer at all.

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -180,7 +180,8 @@ node --input-type=module -e '
 # the brain and its own directory, never the agent, the turn runner, the
 # ledger, or anything else of the brain by relative path. That is what lets a
 # tool be read, tested, and moved to another runtime without the agent that
-# runs it, and what keeps `admit()` inside `execute` rather than beside it.
+# runs it, and what keeps `admitEffect()` inside `execute` rather than beside
+# it.
 node --input-type=module -e '
   import { readdir, readFile } from "node:fs/promises";
   import path from "node:path";
@@ -205,12 +206,11 @@ node --input-type=module -e '
 
 # Admission has one home in the brain: a tool module's own `execute`, under
 # `packages/brain/src/tools/`. Nothing else of the brain, and nothing in the
-# host's brain wiring or the memory package, may call `admit()` or
-# `admitEffect()` or reach for either, so no path can hand the host a raw call
-# to admit and carry in one breath — the notebook's two writes included, which
-# arrive at the host as admitted actions like every other. The check reads
-# import lists rather than call sites, because a file that never imports
-# `admit` cannot call it.
+# host's brain wiring or the memory package, may call `admitEffect()` or reach
+# for it, so no path can hand the host a raw call to admit and carry in one
+# breath — the notebook's two writes included, which arrive at the host as
+# admitted actions like every other. The check reads import lists rather than
+# call sites, because a file that never imports the gauntlet cannot call it.
 node --input-type=module -e '
   import { readdir, readFile } from "node:fs/promises";
   import path from "node:path";
@@ -234,13 +234,13 @@ node --input-type=module -e '
       const text = await readFile(file, "utf8");
       for (const match of text.matchAll(/import\s*(?:type\s+)?\{([^}]*)\}\s*from\s+"@sidecar\/actions"/g)) {
         const names = match[1].split(",").map((name) => name.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0]);
-        if (names.includes("admit") || names.includes("admitEffect")) reaching.push(relative);
+        if (names.includes("admitEffect")) reaching.push(relative);
       }
     }
   }
   if (reaching.length > 0) {
     process.stderr.write(
-      `error: admit() is reached outside the brain tool modules: ${reaching.join(", ")}\n`,
+      `error: admitEffect() is reached outside the brain tool modules: ${reaching.join(", ")}\n`,
     );
     process.exit(1);
   }
@@ -549,13 +549,13 @@ fi
 # whole point is that the set is entered in one place. The type system already
 # refuses an object literal, but a cast spells the brand out and would enter the
 # set from anywhere it is written, so the cast lives in the two wire modules that
-# define and re-shape the brand and in `admit()`, the one minter. An Effect
+# define and re-shape the brand and in `admitEffect()`, the one minter. An Effect
 # `Schema.brand` would be a third way in, which is why admission is not one.
 admitted_casts=$(grep -rEn --exclude-dir=node_modules --include='*.ts' --include='*.tsx' 'as Admitted\b' \
     "$SIDECAR_REPO_ROOT/apps" "$SIDECAR_REPO_ROOT/packages" "$SIDECAR_REPO_ROOT/tools" |
     grep -vE '/(packages/actions/src/admit\.ts|packages/wire/src/admitted\.ts|packages/wire/src/testing/admitted[^/]*\.ts):' || true)
 if [[ -n "$admitted_casts" ]]; then
-    printf 'error: the Admitted brand is cast only in admit() and wire'"'"'s admitted modules — reshapeAdmitted() is how everything else re-shapes what admission already minted:\n%s\n' \
+    printf 'error: the Admitted brand is cast only in admitEffect() and wire'"'"'s admitted modules — reshapeAdmitted() is how everything else re-shapes what admission already minted:\n%s\n' \
         "$admitted_casts" >&2
     exit 1
 fi

--- a/tools/oxlint/anti-slop/effect-edges.json
+++ b/tools/oxlint/anti-slop/effect-edges.json
@@ -22,7 +22,6 @@
     "apps/web/tests/support/hosted-store-database.ts",
     "apps/web/tests/support/no-database.ts",
     "apps/web/tests/support/sql-client.ts",
-    "packages/actions/src/admit.ts",
     "packages/analytics/src/sender.ts",
     "packages/brain/src/agent.ts",
     "packages/brain/src/effect/carry.ts",


### PR DESCRIPTION
P12-15f — `admitEffect` is the one gauntlet; the `admit()` Promise door is deleted.

## Summary

- `admit()` in `packages/actions/src/admit.ts` is gone. `admitEffect()` is the
  only gauntlet and the only minter of a `ValidatedAction`; every caller now
  composes it. The one `as Admitted` cast stays inside `admit.ts`, and the file
  keeps its name.
- `executeSessionAction` answers `Effect<ActionExecutionAnswer>`: admission is
  `admitEffect`, each provider write is `Effect.promise(() => dispatchAction(…))`
  mapped through `fromProviderResult`, and the refusal comes back through
  `Effect.catchTag("AdmitRefusal", …)` into the same `fromRefusal` answer as
  before. `fromRefusal` takes the `AdmitRefusal` rather than a `Refusal`.
- The two testing doors over it answer Effects: `@sidecar/actions`'
  `admitToolCall` returns `Effect<ValidatedAction | Refusal>`, and the provider
  contract's oracle admits through a local `decide()` over `admitEffect` run by
  `@sidecar/wire/testing`'s already-allowlisted `runTest`.
- The hosted carrier answers Effects too: `HostedActionCarrier.admission`/`carry`
  and `CloudActionExecutor` are Effect-shaped, so `brain-host/tools.ts` no longer
  wraps either in `Effect.promise`.
- Deleted together: the ADR paragraph for the door, its row in the shim table,
  and its `runShims` entry in `tools/oxlint/anti-slop/effect-edges.json`.

### Deviation from the plan row, called out

The plan has `executeSessionAction`'s caller take the effect directly. On
contact, `handleSessionAction` is a `Promise<Response>` route handler and the
only runner available to it is `runWeb`, whose layer requires `DATABASE_URL` —
which an action never touches, and which the endpoint's own tests do not
provide. So the smallest correct thing: `executeSessionAction` answers an Effect
as the row asks, and `action-session.ts` keeps its injected `execute` seam
promise-shaped with a new module-level `routeExecute = (options) =>
runWeb(executeSessionAction(options))` beside the existing `routeRoster`, which
already runs its effect at that same edge for the same reason. No new shim, no
new allowlist row, no test churn. `handleSessionAction` itself becoming an
Effect belongs to the web-route lane (Phase 10), not here.

Two ADR ordinals ("is the fifth", "is the sixth") sat on the paragraph chain the
deleted one was fourth in. Rather than renumber — which every parallel PR then
collides on — both now read "is on the allowlist too" / "is on it as well".

### Also true after this PR

`repository-checks.sh`'s `as Admitted` grep and its brain import-list grep both
still pass; the import-list grep now names `admitEffect` alone, since `admit` is
no longer a name anything can import. Doc comments across `@sidecar/session`,
`@sidecar/wire`, `@sidecar/brain`, `@sidecar/memory`, `@sidecar/host` and
`apps/desktop` that said `admit()` now say `admitEffect()`.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green (repository-checks,
  biome, oxlint, knip, tsc across all 27 projects, all four vitest shards, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this workspace
  is a Linux cloud sandbox with no macOS host, and CI runs Linux only. This PR
  touches no renderer or UI code: the two `apps/desktop` files changed are
  doc-comment renames of `admit()` to `admitEffect()` with no behaviour.

### Visual evidence

- Fixture screenshots inspected: `not applicable` — no panel or renderer drawing
  changed, so there is nothing new on the rendered panel.

### Physical-device evidence

- Screenshot or screen recording: `not applicable`
- Physical-notch check: `not applicable`
- Device/display configuration: `not applicable`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — `check.sh` green locally; `verify.sh` not run (no macOS host here) and not required: no renderer or UI change, only doc-comment renames under `apps/desktop`.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — the 23 `packages/actions/fixtures/json-schema` goldens are byte-identical; nothing touched `definitionOf` or a tool spec.
- [x] Gateway envelope goldens unchanged. (CI) — no gateway file changed.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no assertion added; the one `as Admitted` cast stays inside `admit.ts`, now in `admitEffect` alone.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no ported file changed.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and the shims `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-run-promise-outside-edges`) — one run was **removed** (`admit.ts` is off `runShims`). The provider contract's oracle runs through `@sidecar/wire/testing`'s `runTest`, already on the list; `action-session.ts` runs through `runWeb` from the edge module `apps/web/server/runtime.ts`, as it already did for `routeRoster`. New runs in `.test.ts` files only, which the rule exempts by extension.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`/`fs.watch` outside the files `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-raw-async-primitives`) — none added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual: `vitest run --reporter=json`) — `@sidecar/actions` 112 → 109. The three deleted are the `describe("admit")` block in `admit-effect.test.ts` that tested the door itself; each of its three claims is already held by an `it.effect` case over `admitEffect` in the same file (the refusal's reason, the roster read's own failure as a defect, the minted payload). Every other package unchanged.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `admit()` is deleted outright, with its ADR paragraph, its shim-table row, and its `runShims` entry in the same commit. No new shim is introduced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — no `CLAUDE.md`/`AGENTS.md` names `admit()`, `executeSessionAction`, `admitToolCall` or `hostedActionCarrier`; `CLAUDE.md` is a symlink to `AGENTS.md`, so the root pair is byte-identical by construction. `docs/adr/0001-effect.md` and `scripts/repository-checks.sh`, which did name the function, are both edited here.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged. Nothing about what leaves the machine moved: the same gauntlet decides the same actions on the same roster reads.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — no new bare specifier anywhere; `@sidecar/providers` already depends on `effect` and `@sidecar/wire`, `@sidecar/actions` already depends on `effect`, and `apps/web` reaches nothing new.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — no import path changed; nothing Node-reaching moved behind a door.

## Notes

- Blockers or follow-up verification: none. Bases on #1282 (P12-15d) and #1280 /
  #1281 (P12-15e), both merged. `awaitedGuardedRead` was already gone from main
  when this branched, so there was nothing left of it to delete here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)